### PR TITLE
chore: update runtime dependencies to stable_20260519_1

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 25.2.2.4
+  version: 25.2.2.5
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -13,7 +13,7 @@ build: |
   bash -e build.bash
 
 sources:
-  # linglong:gen_deb_source sources arm64 http://10.20.64.92:8080/crimson_runtime/stable_20260415 stable main
+  # linglong:gen_deb_source sources arm64 http://10.20.64.92:8080/crimson_runtime/stable_20260519_1 stable main
   # source package qt6-base
   # linglong:gen_deb_source install libqt6concurrent6
   # linglong:gen_deb_source install libqt6core6
@@ -176,822 +176,827 @@ sources:
   # linglong:gen_deb_source install libfcitx5-qt6-dev
   # source package deepin-shortcut-viewer
   # linglong:gen_deb_source install deepin-shortcut-viewer
+  # source package uos-license-content
+  # linglong:gen_deb_source install uos-license-content
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_arm64.deb
     digest: 8640b3a520c753202b7522eb12370205694c88cd354b3b24d4bb5fd25d51fba2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.41-6deepin10_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.41-6deepin10_arm64.deb
     digest: 505593822355b4cfce867bbe99a0a67912b13b615c3009f63a3e27d96c4dbcfa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dbus-broker/dbus-broker_29-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dbus-broker/dbus-broker_29-3_arm64.deb
     digest: 85ea96ecd1c36047a88b101d796617cab7fa4158f08180e7d275c799fb1ad97a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt5integration/dde-qt6integration_6.7.34_arm64.deb
-    digest: c330f9175458ce2de942fca5e908868eede8fed7e2bf949d2848427796321155
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt5integration/dde-qt6integration_6.7.41_arm64.deb
+    digest: e9b3718806b4763d0280070dfa47643c0d6709e1695542fa4064928b7bbe176e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.37_arm64.deb
-    digest: 85647c7a4e9f9d5a715b7614bfe39c808d2c523027747ef61959a666b1d06927
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.41_arm64.deb
+    digest: 63d4c2b0c387ce7ef93889bae2390c45e96049b590572f44e06ab07753244db1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_arm64.deb
     digest: 14c2e40bd300f261f972a8f029e7276efbb5d800c5c0ff32cfceb3584f8529a2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
     digest: 56be397887b8d4a953202fbfc4342e7a675ef386497abaf0d7f95521340c28a2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dpkg/dpkg-dev_1.22.6deepin7_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dpkg/dpkg-dev_1.22.6deepin7_all.deb
     digest: 4c292d48c0900e0b3939322c8bc7aeba358873c73f608f5f680de8e120d387de
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.37_arm64.deb
-    digest: f45f5fab1015a400e9dd73102f1c843579f9559c7e74e528d6edc2227b8cfaa0
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.41_arm64.deb
+    digest: 59f9708810899f8eecfcbbcefe0f27f88601870455d44be929dfe3bffa70722f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.8-2deepin3+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.8-2deepin3+rb1_arm64.deb
     digest: bf16b02ed463d630ae4c9df0fa6b99b37b01de9d5d70ed66b019c3a814c71e43
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
     digest: fafd08c872d1279aa0bde2e0bdf40a57721961934c0593352b6a2c551aa232a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
     digest: ef932bad267f9d4d49c0c376ae1d0fc1a9b595054f8450d42b2a0d6621bc7084
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_arm64.deb
     digest: 1afc84a191b5f3819a8bc441315d4ab876409ec711acf1af3eda81659f9e3abb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin6_arm64.deb
     digest: c94dd31cc7997ce06e4dac98db1e96f72d8ad8526e40f76935393edda2616c24
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
     digest: cac541f3cf746d006b71a08f88364b6743222b8956fda9a7cbd35ffb1cf32ed9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_arm64.deb
     digest: 70ce30db93ccf7870f384aee1946b51da113cf55c7b046c443e8627d35cf73c9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_arm64.deb
     digest: 321b50e4ee0efc4aaa9e67168e4b88216733e1c012d269e6e9f2c04941a66ec0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/b/brotli/libbrotli-dev_1.1.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/b/brotli/libbrotli-dev_1.1.0-2_arm64.deb
     digest: 016574d411e89311351ae6117b766a6bfa1ef7c0f49a4e17601200a33c2a19b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_arm64.deb
     digest: 502bf30d0f5d2a06d33495526cb4f5f7929623e87ed3c716aafb91f29565c1c3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/capstone/libcapstone5_5.0.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/capstone/libcapstone5_5.0.3-1_arm64.deb
     digest: 69c419efd4b58c93eadb583e4d1465b9d91355a3eb599c3d6ac0dcfacb685d8d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_arm64.deb
     digest: 39486fac0b8bd52f8641e2586befaa00aeb6a03106f3b6c99e64039c8e7b4a6e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_arm64.deb
     digest: 0a6ac3348d454cf7a354cfaaf03d67a74c12168356fd5cd896919083f1d3944f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin6_arm64.deb
     digest: 1668093825661c28eed30da1e27aa7b9895d7a7535917bb37f8002001199c05d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin6_arm64.deb
     digest: 49dfce2f8ab5ed235610d14159cd33fd212183044108ca59ebc4cc810356d2dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/cups/libcups2-dev_2.4.2-5deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/cups/libcups2-dev_2.4.2-5deepin4_arm64.deb
     digest: 6732dcfb2e2ded92560b06e21136631221e2ae051ac17e897d449d9242dceef8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin4_arm64.deb
     digest: 15c65fd933b93c0f69790553ec32f79be3df565a43ff3882ed72df46f6ba5241
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_arm64.deb
     digest: d5e52d889f15c80ffe7214c06605d831488c2650ec00d7c9eb9b50ebbc108133
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
     digest: 78e9245e377c8f61009cc60d2b55001aaddd7b656fceb916b3ba8f07344251b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin7_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin7_all.deb
     digest: 04549bfa8689f8ebc2759529bd4c8acb8abca185cf68668033352ef9b546e57a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcore/libdtk6core-bin_6.7.34_arm64.deb
-    digest: e61855310f68c1c9a4298b5dc845dcb8d89c69cbdc4cbd2acf313391fb3f27e2
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcore/libdtk6core-bin_6.7.41_arm64.deb
+    digest: 780e9d426658bb72aaa8c73430b23f414db838b4ada48b55fbcd7b69a1677ddd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcore/libdtk6core-dev_6.7.34_arm64.deb
-    digest: 2e4f803a74ccb66b9708a3435026b26170813a716b53a8a5e7ed8b59428a7b76
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcore/libdtk6core-dev_6.7.41_arm64.deb
+    digest: bc6200cde13a278a78ed0ff48d3301ce9522ef0f8beb951a4094d1c4e386b4c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcore/libdtk6core_6.7.34_arm64.deb
-    digest: 38a178e518d4115d0c6db92401c9d02a09bdfe2af8bddf5e0018c6d4b17b7519
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcore/libdtk6core_6.7.41_arm64.deb
+    digest: 4ff90a1c7534caa987c8c7733d467b2d3defc29ca10ae63b305ed995dc96ba95
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.37_arm64.deb
-    digest: 9cdf60eb92f3d097c77e0d68fad16e7c3a818e9b4dad66c5fb62c33dff7109c3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.41_arm64.deb
+    digest: e774f9f054877d7da0bccb11b36c016b2d0ad8f5d8031e619c44f59b79c61370
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.37_arm64.deb
-    digest: 32f43075ab83d364ec599b6c2bae27102bc9252ca16e51babd340cf5ee803e83
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.41_arm64.deb
+    digest: 8c0174f5647b1eb10ac03e64931ec0e9b29c947941e2274f2b2684441a719ab7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkgui/libdtk6gui-bin_6.7.34_arm64.deb
-    digest: 065bcdd93734de1f209a61460c4d34d88450ecb731c0918ae5bf56101f1e9c23
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkgui/libdtk6gui-bin_6.7.41_arm64.deb
+    digest: dfeb607d29551b2dfa9499ed089eb168ff62919e544295bea19988719414920c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkgui/libdtk6gui-dev_6.7.34_arm64.deb
-    digest: 65c8e6f137530865453d7399caa1901667611e6e89edd149f2aca48bf9eaa68e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkgui/libdtk6gui-dev_6.7.41_arm64.deb
+    digest: ceefd4d7ee8f53c4d8c34074d2456d0f69e9e3e832a41078d9b4d1fcf84512c9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkgui/libdtk6gui_6.7.34_arm64.deb
-    digest: 5a3e6f8b3f84680e21bf6bb488d0521c39ce26e5b8fce800a090783cf90370a9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkgui/libdtk6gui_6.7.41_arm64.deb
+    digest: 6a1d5b1911ee2e8310425513fe969be269c33005e8ab6072ecd5482e36625132
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtklog/libdtk6log-dev_6.7.38_arm64.deb
-    digest: 23b65c52814cc91442329d3ce26dd4babfab5a02cd8725e80b5793489e7c6e42
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtklog/libdtk6log-dev_6.7.41_arm64.deb
+    digest: 75689eb9ac1f801981461305be7ade90ffe6f772b7a0063607eba0af0a900acd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtklog/libdtk6log_6.7.38_arm64.deb
-    digest: 4b0ad83f60121bcd15467e601bad509d4899ce036488267efaa3bf67d1f23e16
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtklog/libdtk6log_6.7.41_arm64.deb
+    digest: 44b89fe98025cf4de0966a05a301c23c0a7bc4b068d4bef7987744c13feaf839
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.37_arm64.deb
-    digest: a64cc6b711061d94e931e4da9ab6e57671734f65f89828e35449a55c9338ab0c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.41_arm64.deb
+    digest: 5222223410ccfb08c4068ea74bdcc8baf5dab8472e5b52ce4dc0ca357e9b1b38
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.37_arm64.deb
-    digest: ef47bf70db207a691fc229f6b6eedc167bc40fc8a552bf66a559384b90e39de2
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.41_arm64.deb
+    digest: 78382ffbb3cf462c36db4bc3eb59cbf23402c1a73eab49963972625497820fe7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkwidget/libdtk6widget_6.7.37_arm64.deb
-    digest: e51d0acbd239a10e7c4832e60b97bf2d747dd2236995f916ac02f65fc7e52096
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkwidget/libdtk6widget_6.7.41_arm64.deb
+    digest: 975133ceb269bd346ca3a8a935fcb0a524c5834f16fc10af7b47db5979e06bb4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.38_arm64.deb
-    digest: 8745cf781c149e16024cb56135ded531a3e7790b4e9f72d4ac39c228769e98e5
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.41_arm64.deb
+    digest: 4da7c4ba4b7bee5ad1ff9c6f2c7f27c611a0484b9a044cb4d3f968a2ec04252f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcommon/libdtkdata_6.7.38_arm64.deb
-    digest: c75e1149ad67de206e4cfb883da5452b100f642a51ae820390df3ba4cba426b0
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcommon/libdtkdata_6.7.41_arm64.deb
+    digest: 2e6339a50710e6d1d847ed9a4265b2480031b62e7fefa6c8b5fc37162a7e9f2a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_arm64.deb
     digest: d2e39d9eadc5fc955478dbe6f1a66627a770ffbe8f165f1f8700934f8263e576
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_arm64.deb
     digest: fbbe2a51d531e25bc6bd01b2a732ea480411f065940a2b581d47dcd98ec7fcc3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/e/expat/libexpat1-dev_2.7.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/e/expat/libexpat1-dev_2.7.3-1_arm64.deb
     digest: 2f348335a62c25ec821df03b732dd9f26a92ae300054f3baa9af8689e1e10c21
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_arm64.deb
     digest: 9031aba011c7fbda1347bcbaf9351128ea600807b5f303835af17729e81ab28f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.8-2deepin3+rb1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.8-2deepin3+rb1_all.deb
     digest: c5323498567c4b1fd58c620d024a153dc9ed17de13291d25e41f89a214007b62
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.8-2deepin3+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.8-2deepin3+rb1_arm64.deb
     digest: 031aaab648d0fb1c457d499fd8a10ff29f2f9bb03dcf38db0c62346fbdbc852e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.8-2deepin3+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.8-2deepin3+rb1_arm64.deb
     digest: 82ec9bde20668ae033d6be79f693cfb2213732c05c081ba7f9c8280eccd19202
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5/libfcitx5utils2_5.1.11-2deepin13_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5/libfcitx5utils2_5.1.11-2deepin13_arm64.deb
     digest: c1895d9798227f14b900f84a004ff45a28a3d436da6d589e3366e6261d186c02
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
     digest: 44b6f1a9aceead0cac121cfd13cdd9a529eb2b60522f8482c7dc4f67432d1904
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/flite/libflite1_2.2-7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/flite/libflite1_2.2-7_arm64.deb
     digest: c78ff59f928670a34074654ae5506c4f021af1ba56d9ebb4ba82aa7e49a0834a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_arm64.deb
     digest: 510d2d650a4a84adfd68c2ca880c8b7902ebe8fa14646f8544252189caa22eb3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_arm64.deb
     digest: bbbc845e4a6ade7d6fe9d7147e9891f1bcb60c971ef8d0ab7c253d7089fc1f8b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_arm64.deb
     digest: dc1cc27076ac172ffd75b7fe88d5889be20c84eb0dbbeeff2a29f24c84d965dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_arm64.deb
     digest: 67fb7f1a7f5bf707a6dcead0b5b044c1704f454c2a51050fcb020ea9b1317913
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_arm64.deb
     digest: ef605bf23fa580844d6a5faa61caf503f3825bc69acc9e30dab40689116a2627
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_arm64.deb
     digest: 4a16ad0b756f1336f01999c1c55cd69bb576416f985bf0445c5f08cbc889ab96
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_arm64.deb
     digest: 894d0a7818c905544b7114e8c7268a3c8dded4395d3d859bdcb774e546e7ac98
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_arm64.deb
     digest: ff60370ae98f4515ea9eda99af3ab9d468b53b23bdd22f4b51abf8064655e810
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_arm64.deb
     digest: 6be533a6b6cb8b661664fedbe661b316edd0bee46f51fe598d300c2efaf95728
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.6-1_arm64.deb
     digest: 06b977fe892b4b345194c8200eacaa8ad191c3b61795b10ec1ae3488e7b2d923
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_arm64.deb
     digest: c952bbe64709d944821b367c5c211af4447ddb59f58f1c2b2fa264ab234890bd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_arm64.deb
     digest: 97b751c1e82af92962c3688f1bc9c0cdded3ea5bacc43d478f0780d22f8d6e6d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_arm64.deb
     digest: 1af178c5a43fc3f1a40d90a4890bf8a00372449495bc32e6ddd82165927b3591
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_arm64.deb
     digest: 0c312f699653f007733afd743554d7200cc43d9fa3d74ba23622165f75cf23f0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_arm64.deb
     digest: 18bc7373f096e8017e59bfdeb551589ca0fe341dbbba016b2d648914770fe3e7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_arm64.deb
     digest: 9a6aaef5f1bd4c34230d194a5d13354b0e614fe330d77bee0c293b9a627ca752
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_arm64.deb
     digest: d554b612e70c2416c6d831b575c1bc1c3f4c0143454ada80203e08f918143e77
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_arm64.deb
     digest: 7eb0cf9914476bdf669f0087c7fcba1d0cfd49f9697804d72fd2869e6fc3ecf6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_arm64.deb
     digest: 4355b250325f762945b8d68dbb1e39fd0847230f9bf56284c35d4a69aa819e5a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_arm64.deb
     digest: 1084fe140088878214dd72f6c8ebf4f4835b83f542ed443ce79cc2f43821d6d9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_arm64.deb
     digest: 82d472f20711c3b0eee4afb2b8bc8a0971f6fb7ced7612317f07597768e6ddad
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_arm64.deb
     digest: 0e91a2383f5ab980fb06cb347c66dc6b6480a7b76cb67ded44bb4b183f295d21
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_arm64.deb
     digest: 9516df25229fcf17ab431b82f89da91c6defb1aad63df171ac3370ba0fff48cf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_arm64.deb
     digest: 53601fc7779c338a250335a69a55adecec0f0f6f16f0fb7ccc69437188c01947
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/md4c/libmd4c0_0.4.8-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/md4c/libmd4c0_0.4.8-1_arm64.deb
     digest: 8b58cf124cb0a435765f6cbc7bc8a59d431a8f84babbc2956beb1a46b53b99f5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_arm64.deb
     digest: 15763cf880b4073ba036e05f2a3b9b46aa43802f9d2c49848fd315a9229d9be8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_arm64.deb
     digest: 62f3c994934747f7cb43813a34b1090787d0f7471d4c1f0607b2ad476f5f7105
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mpg123/libmpg123-0_1.32.8-1deepin1_arm64.deb
-    digest: 54405180731f47ec74f3cad85575beb66fa5d8f2bafc20e414f90d1515dd0ba8
-  - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_arm64.deb
     digest: 17fc6b739d5d25e6139f8786daa9ac90b81315dfde9df401d7a8896831bc1828
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mtdev/libmtdev1_1.1.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mtdev/libmtdev1_1.1.6-1_arm64.deb
     digest: 646172dd88b260728ef1da45a78d41c78161a8341d0ce43de738c63f2e4089ca
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_arm64.deb
     digest: 06f3609b64811a80941b259736bb1f71a58633df1300b979a4458fd92a3d634e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
     digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_arm64.deb
     digest: 218417ca4ee32acb47bd698999e03414161810f034ee895f54a75ed79b15345a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_arm64.deb
     digest: d52a6102a07d9cff9066f0e3ebd802ab14e119bd1f9a890999be8cfda4c2cdce
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_arm64.deb
     digest: 04f4ffdf19ebd3ccfbcbc32489b3fc651ef75dd1b33cae10e5ecb3c8c4287332
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pcre2/libpcre2-32-0_10.46-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pcre2/libpcre2-32-0_10.46-1_arm64.deb
     digest: ce2687d8eb755b1a3a7cebfc0fbbd94c2ceb01e7fa4dd7f84615c424a91b3427
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pcre2/libpcre2-dev_10.46-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pcre2/libpcre2-dev_10.46-1_arm64.deb
     digest: c36a3f37e6ac821c11b69b2cc0fbd23ee36a526f69bf249f2f32c566b24928b8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pcre2/libpcre2-posix3_10.46-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pcre2/libpcre2-posix3_10.46-1_arm64.deb
     digest: 83bbfc7bb285e5791b4b3eeba00660961f16b202349000766960c7c8e77b9604
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_arm64.deb
     digest: f09601fbb60184cf2257b12a7eec5e39ae0d8659ae517bb42de686abc791f5a4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_arm64.deb
     digest: 225ac12d1f1dbf507b8b994fcd0e127f24287b2f5cef5a2b86d85677c8576ec9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_arm64.deb
     digest: 36ef5b74e950afa328783b48852de9093f39a157287fcc5d407671a752de8212
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/postgresql-16/libpq5_16.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/postgresql-16/libpq5_16.3-1_arm64.deb
     digest: d1cec167267a17f161a55acebef996462e7a4244d41136d4bd27ea24c7c2faae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
     digest: 3c2fef66a85ca8d8219283c1402eb66500b8587fa4f4495d327515e12b71e710
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 50018565d4dcd103570cac23faf2cf9f4f6cf641cb0abf4cd8bd31f309ce7352
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_arm64.deb
     digest: 503f5c8e330d3b7cf0bf0ced200124c129b4157dce1f4f9ff2d9ee333e30ffa6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: b01151584dd197701a10b0b018a9b93305875dd2ea54902e928482749b40ce4a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: e327d9ef11c5bea99c5a49461aedd4cc7e26f6f768013f0099a2ca648ec899f8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
     digest: 1a53ee6f88e873fcb1a054617b98500f02b09cf0336a96be48f1c3467bc5d777
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
     digest: 1f2ad8c7d25fbd354c77a502f365fce9227af547a0891450fdd82e114c3ea219
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: b64fecf98e2e51ef0a7b4fc256b97a41ee72d24fbcb363308cb5f2155050f183
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
     digest: a3621bb01bd9bdc62bd2896bef51cc01db271694a10cec7841c47c33507fc465
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_arm64.deb
     digest: 4f28fb916cd81a9d1275944c7d7b1215c67c9f11782559c49d289af2c9034d2f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_arm64.deb
     digest: 4e437c832e71179df54f516e31c37fae3436b9c3b0c6900c2649b17c0030788c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 4ab14942ae699f75207feae8b1f7f0469216e4ad2a466149eb04e89d97f08890
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 3ac10cf6a55bb88023a688dec8d6aa6b116df5ffdd30676b8de7ee309e9d3572
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: a20ef808d339999be841908377bbe8c5c53d8cdab9c09472b1baddfaebe6f6a8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: b853bd2864332c035d7d1afcc853f0b0a1f94d5f2bbc26dcd3b70a810083c456
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: b63c398db8b18ab72af4d623d473f4b42eb5c76bffce6aece3de5167af37cc32
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: b05a10817b833b8ab7d8e23a25880b7f2c535e36083c28e2cbc79c04da15a968
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: b2556a732833f2785ecf08c0e26d9ac456a0da1a5af46b1fba6602d8a0bf64e8
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 0d2a5d361576643136e5171afa0d24816096e46021f5b03a21cc35e581a69fd0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 1e454487284e662e5ead6611f6d66a1aadaecd6d0e4ae0e5b852e91467c6415d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 519c202277abe8e00ee20f4d5d126a72046c707d6c4b43417a8b1f3ccaa9fbae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_arm64.deb
     digest: f6209c88dcdfeabfe2bd4954c80ef551c8a2dc674a13f91ba018cbb2ade1628f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_arm64.deb
     digest: e1158dab50cf7a78709684e2593b7f5909acbbb15469fa5e8a9bc08af1663203
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_arm64.deb
     digest: 35ed2555ca02d69c8d8ec4c2d571077637e2f5e082eab63a430e4a23e178ffaa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: a6a9218428c9411936a6984710f7818f15a73c220b1515aa908d8d4070fd9204
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 15e2ee7abc7f1df2f52e3037bcb447792642dba244d0246989325c1bd3d7fcaf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: cbca7ea00af4ce9e9876d810502af2bb9c303f32bd3d346a0a344c8661c1af07
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: d2c7aa12223d1ba629d2f1c94080d4847eec46bfdb63331dace2562c2122e33d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 3069a18136ec750cb37894eb2c78c085542bd84cddf6f48dfcb677db533d354e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 72d484c76e05e2ae38a65928131d133727a812ae071547bb93ab9c4eff918270
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 565b48f052d91df0ba8bfb3e9d5863d1c8a2790fb2d60e9d1953de685159576a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 42e29811faa894ee7d67cf7f99bedac067c8c8e81f0de08466af2cceef6db024
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: ed23744a0d1c1430a9fffe33ae11c32b7c64f75c77b875556bf88f1ddd8a57ef
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 9b50ea79dc265ff87077a3f71f89b320fcd743886c2515612dea6a3d1451d2a0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 5578593582808794ad28d4a471adce6e69d839c19ef9a4064d8ab3d66ee9f8f2
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: bbee6836064231eb6de4134985079ae0641665e8039ab31f3bce3f472cfa117b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 7d0106c7a840e6dd518d6099b17e27701f852306756a9d0e6da32890f1932a3a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: ff26aa381464c9f5d67cf7b7ae4ff2fb6160b5788be4a4de8fea764d23345afa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_arm64.deb
     digest: 6580d46c45a2b2a72aead40acfe67184e7e15149ca0737d0a594c11f750daf2c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_arm64.deb
     digest: dfe144682ad4f6fc4c0ca580a9b578686cfc69b079e4ce4703d9f20e38abb01d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_arm64.deb
     digest: e4f5a120e18ddf6f1300a6afa9ac68a3de8d6687f1fdabbd26b2dc472e7c65d7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 67c7ed495663467dc9df34e93460c6fbda20c435be0615fbb09206daae0d7a9c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 9bafa1eae1bd63880e08dea75d2261522383c1cb725e3885c7e3d511129b54ba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 3186c6975e916e090ef7c58553fabb4f0be102355479e9a52794921ea269e086
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 6f8929227deb23d1f6a326e4bef382b0417eb3f44b122734c76fe454b57faea2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 4216fcdfb08fb8a1c4047f87673b1f324b8808fe365ec6e4f9bf372c6644ffd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin2_arm64.deb
-    digest: 38dacaa641a54fc3205a54aa5c4b783eaefc8d7a8d997ac718794e271cd5da29
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin3_arm64.deb
+    digest: fe8f2e09cf8b3665f5ab0ce3975f7f441bd1a9fabad9710e08d961c81bc59dea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin2_arm64.deb
-    digest: 3356f9c76788d49e2f9b9661311e4cb8137d957ac91a787f5e17f441b9211ea4
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin3_arm64.deb
+    digest: cf5f1f39bb7dbf2854673d6a2e168072adc3b9c574a735e607714afcf7c70526
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: e91d5b942949e033d16878ff68f9037a360797c6a23eb6a4ceb457a39a6bec3e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_arm64.deb
     digest: 8191eed7becdeace0c4422bc16c9ec59f2969c83a5289030be44c23c2a64eaf6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
     digest: dfcb32d2b4d90dde2ebd86b2e8376af1f7d5ad9233dc2a943f4144069de82aad
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin8_arm64.deb
-    digest: d5b6bf47a7b2ac2b0fe8499144906c13739c0f08a09bec5086033ebe518b5a33
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin9_arm64.deb
+    digest: d4b3c9bfbddd4a9fe87cb980897e58b80a1b1b7095a3fd9316762eecb37caf1b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin8_arm64.deb
-    digest: 18c42056296b2c293e8c3dd851f11ac856f754b79604738b7fadfaae36b0549f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin9_arm64.deb
+    digest: 8c680278b290bd7f432316f8a4e22ab42d9a8d746c0a43cccf1f7b8deebcea8a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: b7699f349cf26b8f3445dff1e5b0adb4f37142acb065642bc9fdfe4f7f243a44
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin8_arm64.deb
-    digest: 93584924176b3bfc3d15fcb04f68fc859bfd769dd89f268576440bf963f8a577
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin9_arm64.deb
+    digest: a8204c31e6e5f603dbccfb20e11d0f52bbba791a9f3c4a63cc12ad68196ce8b9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 0ec3e9598d80e98be574b9117a97dfc3c0c32e16dbe6bb5ba661876e7061002c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_arm64.deb
     digest: d38dc8bd34b4cf0fe94e16797f662191b91eb9e16f9f0b44bbaaa9b4b4d736f4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libr/librist/librist4_0.2.7+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libr/librist/librist4_0.2.7+dfsg-1_arm64.deb
     digest: a50896e0d12d2d03cc208dd2e7e2e6ff999b3bb1b77e3661a74c20acbe595086
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_arm64.deb
     digest: aa09e909d7f1ba4c18ed4aac21d5aac26637731dbc0580e01cd76ee3cb8103c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libs/libsepol/libsepol-dev_3.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libs/libsepol/libsepol-dev_3.5-2_arm64.deb
     digest: c55790b3f227a9f9b3736f40c03c8881adcf60732ce7be9a04c7b79fed7240e4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_arm64.deb
     digest: d989b877a836aa9d00d3d211dec9ecdbd06a1a18bd5683f154ad12c42f8b5bff
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libs/libsodium/libsodium23_1.0.18-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libs/libsodium/libsodium23_1.0.18-1_arm64.deb
     digest: ed58a5ca7a8a4646f503396064852c8a1ec2da9a377a0626deedd2536172fced
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
     digest: ffeba610e1f0ffa299499d88562b65eece4f9865d8810d3a6194ff5d2cd02b38
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_arm64.deb
     digest: bae9a1c57122e44c7a58b3c3572049080ab0a7546ffeb141b0ab81eaf0fdb698
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_arm64.deb
     digest: 359f8bef6d4a77cd5875d210c50dad400ba3cb6625929fc9fbfa5d56d6027a02
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libs/libssh/libssh-4_0.11.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libs/libssh/libssh-4_0.11.3-1_arm64.deb
     digest: d5067b78f7cd1d9bb9fcc22e5a1184c8d39159712cb14797937dfc13921f47d7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
     digest: 6afa3a2ae947564d05b220d89298c7e6e1f875cb05b4ed1a9a450be99a3ba47d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin6_arm64.deb
     digest: 838cc6ef2900e8ed6de26c0b9463cbfc3abfad8b1dd0379dc3c61ad7a8170472
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
     digest: 41ff44785effab7f081c3d4744d9e9cf25e374c13a00ab8ef93052a0a4d57114
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
     digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/t/tiff/libtiff-dev_4.7.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/t/tiff/libtiff-dev_4.7.1-1_arm64.deb
     digest: 3bb6f3f153594655c49e7b55d5e59c515af25da3d03acfcb24331da4281a253a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/t/tiff/libtiffxx6_4.7.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/t/tiff/libtiffxx6_4.7.1-1_arm64.deb
     digest: ad54f19a895751161cf51a2490e536f61f9c653f72fc933c868ba08a9c00f0fc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_arm64.deb
     digest: 48481125d3ebb3c27907cc158518e7d3bc25c7c527589b08e7cfb56427a04f9e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
     digest: 790a0e469c3b174d03eb0eb64f4a69ddddd95ddfd4b8daf930e4b4ac7cde179b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/systemd/libudev-dev_255.2-4deepin19_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/systemd/libudev-dev_255.2-4deepin19_arm64.deb
     digest: 29962f4a2307ce00fe72dcd351321364dbae6919b34b9c17b71c791f48cc5f32
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libu/libudfread/libudfread0_1.1.2-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libu/libudfread/libudfread0_1.1.2-1_arm64.deb
     digest: 4e25fbdfe08288e6f58cbf5a02a5147f4c2d6f41927020d20cc1a60ce49b5c0c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_arm64.deb
     digest: 03f79776d79c5798181a5c7cbeec4c2af9971b4956e9a574b3d4ea07c742c0a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_arm64.deb
     digest: 1efd5f219b0440fda1a5c2a1b4e05148504576b710f18c374908843d307ac93d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwacom/libwacom-dev_1.12-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwacom/libwacom-dev_1.12-1_arm64.deb
     digest: 3d5a7ebd49f242956b1058290b1a909c4b5e687529d3b4e8530c1556f3d99b40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwacom/libwacom2_1.12-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwacom/libwacom2_1.12-1_arm64.deb
     digest: c07692f2fda707855dbdd2f4586f8f1acf5b9cfc9618db7c08bf3442e4b7af3a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/w/wayland/libwayland-bin_1.23.1-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/w/wayland/libwayland-bin_1.23.1-3_arm64.deb
     digest: 3322bf5f004c10b95c312e95ae90c1bb6bb7b3595caee178d7d02d79397f50ed
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/w/wayland/libwayland-dev_1.23.1-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/w/wayland/libwayland-dev_1.23.1-3_arm64.deb
     digest: d845dfce94123d2388750b820ad1299ac542aae445a29a7aefff300469d88ede
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_arm64.deb
     digest: f783e2d15596e657a9077db7a3dd7e8de84360a27ab504644069df49922a9545
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_arm64.deb
     digest: 9115ed02a3d0d9de956bc1474b608f922aa61feecfd27e267d88e2687caa19b1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libx11/libx11-dev_1.8.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libx11/libx11-dev_1.8.7-1_arm64.deb
     digest: 1c6d4a10271b55eaf39aa83f76851047669a842f2c15b18282f2851bf29644d0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libxau/libxau-dev_1.0.9-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libxau/libxau-dev_1.0.9-1_arm64.deb
     digest: 28ba4c91230a4d8e3caa43b0897bc56960e5b07eb6e8297ddfe3d57c3514457e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libxcb/libxcb1-dev_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libxcb/libxcb1-dev_1.15-1_arm64.deb
     digest: f655f75fb5205cb90667bd2e1b1c08ccd93e0f937d1b4124b10afbab5bd4bc54
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_arm64.deb
     digest: 26b4210ed6ce4e5d1dc2f766ae3b47dc36442294c8b7e8eaed61da9792f76130
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_arm64.deb
     digest: 941544912030ac7a4ef2b1c3944932245be753179c8b83f93f2ecce2286ad833
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/z/zeromq3/libzmq5_4.3.5-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/z/zeromq3/libzmq5_4.3.5-1_arm64.deb
     digest: d0604b09daeb5a092bc3b7d77625f48456e3b5a5a3fb660122d36107e8a14ec3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_arm64.deb
     digest: ca9575f6503945c733c4dc2ce78dee09745bdb6eef34f631212d2311e1d635f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
     digest: 68e19fc7f99e8c9d95a0ce2fdde2af187302ab9421cdfe7913d66a8502fa128f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/lsb/lsb-base_11.6_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/lsb/lsb-base_11.6_all.deb
     digest: f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_arm64.deb
     digest: 0e32f0eef7e7f5effe89929ad9a1c14a2838e5033fa9142cf0b3e6bcb81f8573
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/make-dfsg/make_4.4.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/make-dfsg/make_4.4.1-1_arm64.deb
     digest: fd601544bf60cf407d143282c4fb1296842e0cb583308339bde436df40c45b36
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
     digest: 848333f2b40b586ecf8f0db2b6127398d0423867e689937c4427ab15570e5581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
     digest: 729d9b051d2dcda0d0bf51fee21d3b685093314a0b2283926f1eb11f937cb04c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/patch/patch_2.8-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/patch/patch_2.8-2_arm64.deb
     digest: fcc3a3467e4d443f164f0f2ce59e51f546ac2f8d82d0de6fa03e9f942577d144
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pkgconf/pkg-config_1.8.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pkgconf/pkg-config_1.8.1-4_arm64.deb
     digest: 8b40ce5f7439c482fa8800f2a60160fb34fd46492d8ed397480ca0471b7fc9d8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_arm64.deb
     digest: fb3f32b7b567509b63afab51fdf5afbef9f9af569f10aac490b98d34feab8670
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pkgconf/pkgconf_1.8.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pkgconf/pkgconf_1.8.1-4_arm64.deb
     digest: 141f5145e6adf2f9519d95a6e4ec3b1410e829621777b48c7c48bc02bc779c40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
     digest: 4b0fffc886401daa9acfb53e2b190528e3fad37a49b989c4fae6715004fda41e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
     digest: dc2acf26739fa1e49d3961179086bf8cc99a18daea02fc75e41a6a954a75da35
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_arm64.deb
     digest: f6b80940ecf252aa3d39b142081548a9edc4f3ac59d49ce2fab548f3ae742341
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 2f22f16ed5d8e7d1feba073e7a804bb4d73a009ea9d822db0ce55742ea842e5a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 5aa61415ce5988fc7fb225821131b950f131739e4551b99a7ce0c9a2ba2cf436
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 8b619d5333cb3d7e3d00995828fb0c511e67b6fceb6f71cad560bc72d43055fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 92cb9568a36f3e4b796af59348303b106fcda4341a214e347f5bcd556488ba07
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 0fc66ea7adae0fba79c1a8999865003fb60f247e29cf4aad4143586dd4a5078b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 0c14f5eaf5a49f0b0f60662576ee72475328d0543b767619db6cddf6c49b2f39
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: fea307895b8802b8425f5567f7586a34ad6091e8dc1267d57769849270f90e57
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 9dada073c892d51384f66faca46faa5523a9e0becc92ef30fb33240e414a0478
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: eb834a825e698d1f2c4a736ced2ffa8c62fa4f33a259fc9663d18688261ba84f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 28c223be00887bf47d214614cd7510806067b3c44e189fea8d904089270fd492
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: b982b3e87e0b8f921b1fa2c08cc7a241461258db974e777ee62aa51cf5f270f4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 5f78bbb30e824fb22c6bdb0e227613992a7ad21e6e6e7fd9758c06d998b22c98
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: ae5a2c7a0b6f2f5e4ec3a03ff30cb69dd45170be3319fbdbc6798f1629831513
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 8dd61639036b66ee66c75f56cf8eda6f64718ce313f56301d0792e34c9494783
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 0ac8a3070a311f790592d2bb37a09346361862aae1b3d3e73ae87314340de717
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 7a878f6b9a3ebdecd3897c636497de3acb79c4e9f150a82691299150ab99138d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 7f1acd58b99d7e89a326af761bbccffa8c2f4fd996c6b0fdae675e7acbd33acd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: e2f0ebfa6448bd09a3d7ded5b85127350cbc0b838f904dfdc769df2d119268b9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 3b0767c6656964e82c310af8de07d91945125474e1bd6a3d92af76169462ff1a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_arm64.deb
     digest: 0a4a4e7f77ba792604bb9563b61689c8311a746bc4d5e2c1a10b80fbd9f91785
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: f19eded77cdbc8f0397bb526bc2ed2ae0f663c43a25c56e4521df16a5f1afebc
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: e240a2114fc0f707de9f1c9c87abf489619a05f55d6d2087107ac3f3abf041fa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_arm64.deb
     digest: 18ab6b266e8492e2203479d773b546a203188b718178a69208d4c213be9fdc91
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_arm64.deb
     digest: 0165c450a2abf4ec099df4a3e7e5d1cd253fb3ebef7f23d8a28a95763f14e480
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: f36ec91d5b618033d93bbb9e49ff6e22f1231497f332d5055261acacf2572ff0
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 9ba87913324adaf07b3072b26a19887b347adb858d710d67f783f38cc6fd29ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: a66cd66ab247dbe45760d2504e215940c33bfae00201463e5372975629f40fc5
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 5dcbf8f4af0def0d7b9c28d170a4fde882efe33c884b5ab3dac1029a490465c4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 53ca036046b05bfade9a3c01973025838a04f0c5c4f213caa0d6a368dfcf6dd3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 73d408f4ee428f0985ce766566b55d7d6fb711f08a2f4ed0ca4be7971e3734c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 4320933ddeb9984c3e97ced2d5097fe95b680857438b40da08ef6b62093f53a3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 176cc3fc15b2a0cce2a94321e03c16db394e92493769a4428220a32656a2aaea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.37_arm64.deb
-    digest: 1b853ecca5b742edfbd1bc774da3e5fdbdccf8a1bacbb9cc22dbca39371b2e0a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.41_arm64.deb
+    digest: 90088cb5911ac1c4b70444f4924b82105252b2cb2c6f9a43880e5cb8ca3938ec
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: ecbb81007dda9e930e81a1918fa6ce30db8d4efe891d2713ef7cb78cec712af0
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 636aa4737dd54fa0d23a22938a1ea2d5bea7fccb7ed7ccc545072205221d4c68
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 4690dfc47242559231da84813d5eabb4d41ef34b73a9329d86e735336efc1f21
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: b865d00118ba924222e4785806a0b59edc2da32eb4b0be1334fb7566b9be687a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 268b06efbc6382d5bea8000797ec3db6c80a94c49ef1953e52308a7c972c4bf5
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: d2400d77b81045757d4473de66a6fbf8eb3062e3757f2d6b1ec461c5be9fb0e6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 57e616495f06a46056f4299de116fa4de82c5381aea972bb29630384632a1500
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 110bce4ebb255be4bcab3ca53bc9024b65db9490238f6b45d0fcc9481589da0e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 06b50ef200d1d717badef2da4ff11076748ea6019c3ab618463dee3bc7908fbe
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 058ba43a555d6d87a830a85ca094159c43f90927912d55f8f3f71f8bc3e378c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 102b5d83fb8204c820db9521df74b6a4090b4a4fda5d67f5e304dbd5f047087d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 68eb7fd92062f826e7e237933c0403f8d1e410dc6a73f383598b202db5da9334
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 0126cb8e02e46fa0a818e49b207f43134a25d0f43ba373da12be3f3525d209b5
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 7ed3d8b83d42d4660ff0215b23b9024254156a19b86ea97c11680c0eda0dc7b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: aafbd6f976929dc3f728256a16be17c45a4622c0a6ca4fbf99fa2420b536b2c6
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 108dbdccfd73550c30b3cec29175f858a54f3af1e89e5e6ecb564d40eb671fd1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: de1dac573417492198f472bf25af463ef1e084a3f486963322cfa1527791811c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 2287690cef187c957cfe6b799865a7a8782f581e00282ac1a5aa8f62dc1075bb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: cf9ac15cc5623b9d0dbbf9e8f16d5d540e6f0b5e8be64b1786fd3a0c78e320d0
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 91354b8f26931ae7a873581ec4fd1ea74809718f1158aa8b51df9707518e70d8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 00fda605a7ef92d60820d4cfc26c1f679114c0719052efc4d09b4d723c2840ac
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 30730729b5b83e6881530a059252eb0ed8e0384a2f3ad524f5e366a00eb46136
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_arm64.deb
     digest: 18c3716aa0b734ca7d22e0ba8e51df49ad55c2c76726ee1e4a638007e3044e60
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: d9e944edce14d6d5ccd052cba43007edaf04faa04a2ecc49653ffe150c9eadca
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 0557795a7ddee12b1ccb77c837b47f7de3469a11ed01cb8093c7938699459eaf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 0c48ea3460e173fce080604a4b0a1fea2a2537cc1317f453200721f5e5a79383
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 28f9e916564cb36156b02cd907ce2c8dbda89841ed8ec1e80d4861d5f975cc0c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_arm64.deb
     digest: 9b681bb49432f5a20b98ad7939c4102975f5952efc7dc7ef1058d3ff7a0417bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin8_arm64.deb
-    digest: 261d1048fd51e17271b535ca2f4df932cf0d60ccbb1f3506a336ce76f5982763
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin9_arm64.deb
+    digest: 04d311740a1372296b8f7590471aca7e252fb9f175ae92f32750959a9974fa3c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin8_arm64.deb
-    digest: 1bceb78c43f263c3a28b00b131b13c6d296337574d1d9eaee8cd196fcb057aff
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin9_arm64.deb
+    digest: 537408f45b16b4f140111ecfde8e813f2936956b711c38bafa7821364f1525b3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 60bd1b307dbd245c96450904fd013be1e1820ec1eef664162e7849d7255032f3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 9e8abd40b9edbaa38674d367be309a8b0409ff15aa2b76b0660c35738399e46c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_arm64.deb
     digest: f16c25091859915e16ec9079cf2e640f789fd896b55aa43c4a2b00d7df88c864
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_arm64.deb
     digest: d2fb36d7fceab313a833148a01a0a9da8dd28ae4363dd2391001092cf15019e6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_arm64.deb
     digest: f25523039fc335e2beb3a6082fcce6f9347de89d1bbcfec00d66350d97068b65
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 0a941aef322b1daa86496d808ac68402743bed07f62af7a5685627519d874514
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 9b8da797fa21519157860632e32ea7a6fc615c05c5aecc01168b170954d42284
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: a8c77834a37db73d4f0054acaf26d7b7db63288938bff2dd2c610d96183caa7e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: a964d3096cd94b16c40d4832ab4326379abcf4df236d6e52b07aa4378011950d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 349db53f4177ebcf0f4c4456a59b626f89cb93bdb62ef5add45fee33784a1b3c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: b3cd695d99fe0c145b4c7a267ce2e6e4ae6d37abec3776af4d9e04f39cbca085
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: e027589314a39a3c7d6ab332091dec2a19ff8aa30cb58ba4535f056e39b758ae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
     digest: 7240dfd58e097adaa152de41b86457f9933cab56d919b7fbaffa783da48ddc4a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_arm64.deb
     digest: d1c40016e70c0d9575429adb35aea04328b2b051d0c41e801efc0ca1acf75308
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_arm64.deb
     digest: f5599ff2546d1f99133d853e039e11193f45e5654f2bcb835e26218b52dd15e9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
     digest: b726420f3a1803c2d33e714cd29b9eb757aef9a607a42d4d9a4257331d30b4c2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_arm64.deb
     digest: d024d7f1dc80124397a3d4a41f4d2015cc72819d7933c0e5ac1cc2331b1ae548
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: c458c98665980465597917918a3d141e07a3ccb439257b483ef6e55ade2a8074
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 0c1909606f4c351a2f39c3d0739038d835882560321237cdf11985f5edc0d077
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin10_arm64.deb
-    digest: 9af35c86ca6d27920087d73b8292a9b63983078abb888661d6422c854c9424b3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin11_arm64.deb
+    digest: 0a178cdfc646636bc918064da1f61408e775a59024ef3f4258fe25b31ed4e04e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 0fba54761bbeaa804bdf1a6239f727986c287308e4f0ab5dd48425f52729f22d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_arm64.deb
     digest: b9cff1d9eac542c46a108dd15a20163fdc53abe14fcf21f6be90f98bd14f8127
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_arm64.deb
     digest: 3815c4d7c65d592eb364070ff3e8aeb1e5e1977e3652d5f266bb02cabcae0f87
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_arm64.deb
     digest: 096625f80d868ea9fa76a664ec8d0b821d696e6ed0599be4f3c23e94e1f5b9bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin2_arm64.deb
-    digest: b2218f93bc16793d13580fe21314057500a96acd7f801b796430b8f8f077f26b
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin3_arm64.deb
+    digest: f34eb6595cfb090a23b90536f27e3adbac2b9ac57233493a08045f30c531f8e4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin2_arm64.deb
-    digest: 49b718183a377620349ca223394c6f336d0392016ece4c253e36139f8c9d3b6c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin3_arm64.deb
+    digest: a7ddbd728b46a0716ab064cc4606bbb587b3616143d451c24ccf85533730e7b8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_arm64.deb
     digest: 841e0c1addd40a42a1013e897162d217c27415ea2dd1ebcaed7b61b5de1c8944
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_arm64.deb
     digest: 041a22c18eab9afce1af06a67a4e535ff870edd5404601c75fecdf091120ff95
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_arm64.deb
     digest: a6351936c0c2deeeb6fb3655429b0fa42b24c6d59b7f145f7d19ca7032b1bb68
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
     digest: dbfa88dae0e66fa60e6558fa80242bb78be8dec5b37ea449f85826b1b48cf25c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin8_arm64.deb
-    digest: 4b0ef61de322cf21ae94f5f87049fcd0d48905a59bf03b916c39c9bb09c1ff46
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin9_arm64.deb
+    digest: 7f707545b0d915373378754fc3de837e6316bbeabf8ee66ae0d68700b85186c9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin8_arm64.deb
-    digest: abd592c02a335b69bd0138c860723286acd30e80f3be88012d21eb62dfdb9034
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin9_arm64.deb
+    digest: ffd96a941b2e0dc1d1513bc2b5c441414d0c3e733263966c6ba111887d4afb2a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin8_arm64.deb
-    digest: ec13ad3c7e7f54ef2b3baa8f4b8b53a9f2890285a3f30c1ca632c9683352e939
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin9_arm64.deb
+    digest: 331da06cc563d6a5e3167c5a80021b535c1ffde8c67cbdbce5cd4e7a5c7595d0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin8_arm64.deb
-    digest: b2718daf89b8cb1f2e79c41c3f83c404d7b3226632f5bea496158c59f8983854
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin9_arm64.deb
+    digest: eeb7a6a7f786d428b87eb9a9695d4e5eef0f823d1c253d211a77a0d16d628ee6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
     digest: e70bbe5b35aa1009f8d3e8d58634052977864bad1d854230add6758ef238b1bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_arm64.deb
     digest: ea5d963bc7051ceb4b9ca5c0d1bdef293f67bf8bc40e80586cbf09c8beb1db8e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
+    digest: aae8ac2b6d3198d297d430cdb97e556365be2ff46d06525008ce071d97ac69c7
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/uos-license-content/uos-license-content_2.0.5_arm64.deb
+    digest: e4e3aa73b5c206d5532dbfefa9f3e74491fad469c6df5295abe993fa95ff8853
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_arm64.deb
     digest: 079ee6193e894d85bdb6c51b4318514bf0f788c12560b7bd05b46d6f12df388a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
     digest: 82bff9dab1d74e30bdbc6130f94d1bd361c3c1d3cdad660bd92e5b730c4cba7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
     digest: 29a1888f6b7be54992868b36050c68d6063820ae6c4a2e09ffa2317a7e0b6d6f

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 25.2.2.4
+  version: 25.2.2.5
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -13,7 +13,7 @@ build: |
   bash -e build.bash
 
 sources:
-  # linglong:gen_deb_source sources amd64 http://10.20.64.92:8080/crimson_runtime/stable_20260415 stable main
+  # linglong:gen_deb_source sources amd64 http://10.20.64.92:8080/crimson_runtime/stable_20260519_1 stable main
   # source package qt6-base
   # linglong:gen_deb_source install libqt6concurrent6
   # linglong:gen_deb_source install libqt6core6
@@ -176,819 +176,824 @@ sources:
   # linglong:gen_deb_source install libfcitx5-qt6-dev
   # source package deepin-shortcut-viewer
   # linglong:gen_deb_source install deepin-shortcut-viewer
+  # source package uos-license-content
+  # linglong:gen_deb_source install uos-license-content
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_amd64.deb
     digest: 8b5df0b28f8a7cfc63a1ba4ac369f09a66e19d47a462c4bc8fa8bc552f18a714
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dbus-broker/dbus-broker_29-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dbus-broker/dbus-broker_29-3_amd64.deb
     digest: 68ff1baedb2f4ced1ff5d2f9c3e59bd21e741b7710931e0539c89ef5951df8ba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt5integration/dde-qt6integration_6.7.34_amd64.deb
-    digest: ce82ae3d0ec94422657f48aadff798a9ac826643d696a95ff357569e9e4dccd9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt5integration/dde-qt6integration_6.7.41_amd64.deb
+    digest: 2802f1c359e198dc1f97d7ed7ff774eded624127324511a29b111cdf828684fe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.37_amd64.deb
-    digest: 628e6f21b49352ea5e40bd8e35e1650a68a9ba13ebcddca65185891ffdbd21a1
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.41_amd64.deb
+    digest: 8d60296ee4811c6e945a43ded551580820261271fa69c1808d767d72585f29bb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_amd64.deb
     digest: 8502f9dda05684b5114e9497d55e057aa3911f5b03e27db317a211f4bc3389fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
     digest: ec9d003e1996d9dd70c29c8b1d1ecbb0df0523cb64eb617e2e958fe59ef3110a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dpkg/dpkg-dev_1.22.6deepin7_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dpkg/dpkg-dev_1.22.6deepin7_all.deb
     digest: 4c292d48c0900e0b3939322c8bc7aeba358873c73f608f5f680de8e120d387de
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.37_amd64.deb
-    digest: b86c96f6fd1511d6c40e82c9234e749917c627e4bd82c31e80e0c9f91358e184
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.41_amd64.deb
+    digest: ca511e526055ea605ecafeb6bdde8dd8573cb21eece5dc9efac71974e684b833
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.8-2deepin3+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.8-2deepin3+rb1_amd64.deb
     digest: afcdd83e4141aa0c50986d751011151ac171dd2272054703bba20fd5b8a5562a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
     digest: fafd08c872d1279aa0bde2e0bdf40a57721961934c0593352b6a2c551aa232a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
     digest: ef932bad267f9d4d49c0c376ae1d0fc1a9b595054f8450d42b2a0d6621bc7084
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_amd64.deb
     digest: 3cbcb69c6edaebc428fc9f7c19a4a4e7a057bb980ab6b6f754561e3aee3ea011
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin6_amd64.deb
     digest: c04d5149ac01cd0ed79bc7e786594c069e2f00c9f7bae81c7ae393994669cfa4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
     digest: ad82b2de93cc49cdf37c861b03275245318b1555255639e5e805cf612a40171e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_amd64.deb
     digest: a4d108ebdc3c5710be943be9fc8b480e7db0704da63fb2c041dc2865df4ce4f9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_amd64.deb
     digest: 563f4d3b275996192a906b926390435bb3e444294f8766b8db5ba66f199db55d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/b/brotli/libbrotli-dev_1.1.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/b/brotli/libbrotli-dev_1.1.0-2_amd64.deb
     digest: 87226cff96c560b3ea8b15110f7f2b00047b0cc9dd29c9fdbc372b4d9154de80
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_amd64.deb
     digest: 60e1d9cbac4fafa4f7823e6495212ec02805997e64dead0f40de1d86ff138d41
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/capstone/libcapstone5_5.0.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/capstone/libcapstone5_5.0.3-1_amd64.deb
     digest: 0e6b1c94b28127dbb067f7ded642625abd26fac8bce528aa9bad37e5b66836f8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_amd64.deb
     digest: 1ee2dbafa2c331d58cf10cdf546c760d7a734c5d9fab1b16d2e04e51f6e38623
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_amd64.deb
     digest: 0c0ac88efe846e4cccd84c896722e981be3a276b984541a4aeb67b1a97a86100
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin6_amd64.deb
     digest: 53be885997030deba392d4a712ed8fb36978eccedc9c6afc09e923f358a8fc01
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin6_amd64.deb
     digest: 5cdfdd92ac7febeb21e8a439a8d34f46b694e816e7b4a53a070cdd6b9325382e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/cups/libcups2-dev_2.4.2-5deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/cups/libcups2-dev_2.4.2-5deepin4_amd64.deb
     digest: 2b65597e27b2633a6fa4cde66b9f74cec4b426d96de04fb2cd9f1ba460b9367d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin4_amd64.deb
     digest: d6100be9216b2636af141b875f294538d3850e2005d11baa51055023b7cf9a83
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_amd64.deb
     digest: 04a8d4c536a9f106a9f4b38fdc012fbe745b928e32ef3f05db4704d30c1023b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
     digest: e6c6d028a74d0a752ae638ec19b8239f404c36d676c7569936f31000d25a75f4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin7_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin7_all.deb
     digest: 04549bfa8689f8ebc2759529bd4c8acb8abca185cf68668033352ef9b546e57a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcore/libdtk6core-bin_6.7.34_amd64.deb
-    digest: 31d3ae30642a1234d71899ccab023e24decf9cf4316b69b4017e614ca439e4da
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcore/libdtk6core-bin_6.7.41_amd64.deb
+    digest: b6c96ba1c39814605712285b9f19fa59d1068fdfd617f245bce8bd42f0865950
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcore/libdtk6core-dev_6.7.34_amd64.deb
-    digest: 84aa30a29a6b03a372fb3c7175f85381dd3282eb29e013415258393db43eb123
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcore/libdtk6core-dev_6.7.41_amd64.deb
+    digest: c8b15d17eba87ffc790c405923cd40e3cefde60803ed3bdb9178d56be09d85c1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcore/libdtk6core_6.7.34_amd64.deb
-    digest: 15beee35fb83876d51cdb11e1a614126bff3d5244099b9355dc4ca7437d1752c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcore/libdtk6core_6.7.41_amd64.deb
+    digest: b612d4d0dfd0acd74434f6bfef2cbfd67999e3173e3034389ec38f738c099d4c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.37_amd64.deb
-    digest: c20c11e971113dae4f6778caf1cd8f9d0d422475e5bb289426e0c540c8fedbe7
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.41_amd64.deb
+    digest: 8e16c02f4eb2cb6047c7f80667e371eefd60028dcb6a80a2cb08f65a735de67c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.37_amd64.deb
-    digest: 6c15447108be8104cc9ed8bad9c39b8899d77cf8b6e96051e1490c328929cf5d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.41_amd64.deb
+    digest: 5201aa28d678808e458cb952502624c8bc1098330a4768a4e734d84e7e66b576
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkgui/libdtk6gui-bin_6.7.34_amd64.deb
-    digest: d109847f1eee342a8fe7e3a5aa973fed3755f81c5670eed1e250702bcadd209e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkgui/libdtk6gui-bin_6.7.41_amd64.deb
+    digest: d21e99709695387e15f81907b61e404f69ec3c90b3285c7f3b590dcce1c9bb65
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkgui/libdtk6gui-dev_6.7.34_amd64.deb
-    digest: 43cf589d7a3c4c5fc11479b7f365a8f7b8c29cdb6f1dde60c4f92a6e4ebfbd91
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkgui/libdtk6gui-dev_6.7.41_amd64.deb
+    digest: 6fc6bf39cf9ec385a0bcc463a6726985146d9a3dc5c2075124764055f7d9616a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkgui/libdtk6gui_6.7.34_amd64.deb
-    digest: 7cffc3c72e69ed0bdabfacb98bf35e3c66cc5c747bdd700359d15ecc1ba9f99e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkgui/libdtk6gui_6.7.41_amd64.deb
+    digest: 28a928d8b319154894275843d8b526f454ede82960306f9e4c9c9eec243477a0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtklog/libdtk6log-dev_6.7.38_amd64.deb
-    digest: c4ce6c42c065f0a3ad6b6e9902832cfd45e03d9169b4fc8a58d199cd99a6214d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtklog/libdtk6log-dev_6.7.41_amd64.deb
+    digest: da64bec5ac5591c3e8a31869e5cba3e7712b47bfe8b61f726f5231f218ded221
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtklog/libdtk6log_6.7.38_amd64.deb
-    digest: ab15e5e3a5523ec9adc29d13db35a76ac795deb528e8a6f959f1e72d68064138
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtklog/libdtk6log_6.7.41_amd64.deb
+    digest: a2d1d6788a88be65dd35b67f4a38f9b0ba485e07b405fb99e54bba27b1862def
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.37_amd64.deb
-    digest: e24d7c9135cfe2302dc4e45d3b46ec774c50632a829364f66b4f47fc512ecf54
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.41_amd64.deb
+    digest: c9151c22bf6505cd90c37c401a207e778c88d5b6742a2a306e57665ea06b932a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.37_amd64.deb
-    digest: 4d207d27c9dd59344e3afc04a5c9ee368cb6921ecffeefa67f7633846c50bdde
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.41_amd64.deb
+    digest: a1515b2a6e5440f486f5a06d1732bc2e32c1d170aac3bfe3171424274263a43e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkwidget/libdtk6widget_6.7.37_amd64.deb
-    digest: 060e608b56e8baea65c4d9142147a7295d00d9ac1ab51019ec51604ad3be43bf
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkwidget/libdtk6widget_6.7.41_amd64.deb
+    digest: 122bc9bf69bc55121eee060d3ab4785edb1f0729071f089845724abe4e81b681
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.38_amd64.deb
-    digest: 67a27bb81adfe7d99d6e589f2c0068d48581df6ca4292664501d7e026fff8de0
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.41_amd64.deb
+    digest: d4c0e927d3c428634ab6fb0e7613f536d77c2cf85965f2f898310da2d4771c9f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcommon/libdtkdata_6.7.38_amd64.deb
-    digest: 70935a7d2925c3978ce378eeba79b0b8ad6be5a89a11209c1d5d03dcd10885c3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcommon/libdtkdata_6.7.41_amd64.deb
+    digest: b7c56b9a917b1456ff649b5e49d88b1cc9f89ca6a8d46d68b76d67469bb83d5f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_amd64.deb
     digest: 7e338355abfb198b7fe4ff9d02f4b950f822965712d429e3a623e25509e41daf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_amd64.deb
     digest: 48c0a7c73d835054b291645fa21fd597271e28a6eb98d8b22f2283e364e83893
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/e/expat/libexpat1-dev_2.7.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/e/expat/libexpat1-dev_2.7.3-1_amd64.deb
     digest: c6951644f74c3a2098fb19a42348caf6cb906598093d36661fcecda58e22a835
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_amd64.deb
     digest: 69c8f541c96059330b8b59f110fc1501594f72c291585c04997795f0b24ba105
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.8-2deepin3+rb1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.8-2deepin3+rb1_all.deb
     digest: c5323498567c4b1fd58c620d024a153dc9ed17de13291d25e41f89a214007b62
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.8-2deepin3+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.8-2deepin3+rb1_amd64.deb
     digest: e24bfbc28cfa374cf094bc4f71db8cac5090e78b0fdcf930af08b8f54e14b85a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.8-2deepin3+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.8-2deepin3+rb1_amd64.deb
     digest: 31325e9bbcb1c37e32e0865ad55d2e6ee1bd4dced9cb8ae8588902e4f06d5904
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5/libfcitx5utils2_5.1.11-2deepin13_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5/libfcitx5utils2_5.1.11-2deepin13_amd64.deb
     digest: 3655ae98ebd4096c59141bf3e0830f3ed5a70af85d07387e0cf6389df2792183
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
     digest: eadc61825e77bad028fd5eff398ac0e13da7a08870261058525d3f620d90cb7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/flite/libflite1_2.2-7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/flite/libflite1_2.2-7_amd64.deb
     digest: 8851ce503276f63416a9f1776fe8051b87c2fafcb3ed0990bd4e1572b4ad3ec8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_amd64.deb
     digest: 00a674b9b4c7034dbda109a463cfc89e67f803b2fba83965992754a79e948fb2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_amd64.deb
     digest: f24f727e6c0976f6f7a728eadc4c887c847c6fa241f40c72b0db90d53441fe75
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_amd64.deb
     digest: 96d67a80be9adf8a9418e1dd33d2bf12d36bb12d4518297842fc8de29bf50763
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_amd64.deb
     digest: 6340c9628c7bcfda4c6826a49c52bc8bf28bfb8d12c163eb19ebde7b0ad61578
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_amd64.deb
     digest: 9555387119d2c7118202da7424f3d95a358843cb6e3369135979bf3fb1e7586e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_amd64.deb
     digest: 47e6ec3f082c09540ec0ce8ec0358e9d0d28ea7822e9e7cd5000672f6fd35adb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_amd64.deb
     digest: f6e2df667c442e8ad0305ec62c85227aead61ff85d591ef32ec9de31d086a74e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_amd64.deb
     digest: 5b8281d799f1b3844524c1baa475e4876665b4d6062800655e180586dc0015bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_amd64.deb
     digest: 6f185c6ac2987d5d8ac0f81be7f0377ac34c00ba45ba8d206ae7ef5888bbca00
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.6-1_amd64.deb
     digest: 5e0621339870e5af412c689c0fc54313fa60f09c94262689c3b0b8fd6dead35d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_amd64.deb
     digest: fb9f1c72e40fd7fece5eab37c9eb473bf3d19c84fb808512d60af3bc909a8c5f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_amd64.deb
     digest: b0b603d7732573aed035c0ab43d92a054eb4351a7098fe6f37e4c736c1b5bd12
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_amd64.deb
     digest: b4036cefbbc4f6a5f73f6ac19d3065c52dc6b923691268c5b3032971465c35ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_amd64.deb
     digest: eb9aca98fdaf66cc394f87b65799ae177c2f97ca300e0c55a34ac736525c9733
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_amd64.deb
     digest: 9153a6287da744a308744636d0e39ed6a92c25f51d00d50e0376203a48e300c3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_amd64.deb
     digest: 52cbd20e0fc0708991bf66a0af9f5ad9a18d88a7552a8a1b46e209a2f54d25f0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_amd64.deb
     digest: 7ce8d535aa0768ca1cf24178b956b3bbbc82cca19ce4bbe91ab32c36038ae336
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_amd64.deb
     digest: fbc596effd2b0a596b71e306d120e5b660bd478c8c9d24e47c61b4ce2db33d27
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_amd64.deb
     digest: 126fa110768ecfbb4569ddb66d53621f7007dcefa1234e0ba4f37e364903a607
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_amd64.deb
     digest: 9bf199c57795a3e4c8e7cce1ef1803e32e9d31fc7cb82b5db8275f654e19b655
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_amd64.deb
     digest: 44596cdf0fefdc6412af3e1e0d0a4bdee4762d348cdf3818a2cca0daab437285
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_amd64.deb
     digest: 0e611c43cc8cee4b31dd530ef21f4efbb16caab257685a770b612146e18a6b8b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_amd64.deb
     digest: a81ad1bcbf76123a98aca07e8bb02b9e21a592dfdc7513810335c18b471424b4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_amd64.deb
     digest: 1e2259f608a4bd66990c6ec31539f6b328776721a6ab5893e172802db5b4d952
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/md4c/libmd4c0_0.4.8-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/md4c/libmd4c0_0.4.8-1_amd64.deb
     digest: 9f1630409adb3464aa42afc519d2163a7741d152b53c937eddea55b9fb6fb10a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_amd64.deb
     digest: 256423c8e3c4afcbdf72973db84b1e919187b65955c685ee16f9a5635d436943
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_amd64.deb
     digest: b88f61259a6d84105bed6041a41348d696d49ff8aea65ef1308e84d9399999fe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mpg123/libmpg123-0_1.32.8-1deepin1_amd64.deb
-    digest: 8da2a921507884c5bb32854be4feaa1fcf5cd51d5d41b413e0f75982ad578a9f
-  - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_amd64.deb
     digest: 92553337dcd1837205a4f136419b0cf40956e0975a938ad8e8e7b586659d0e46
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mtdev/libmtdev1_1.1.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mtdev/libmtdev1_1.1.6-1_amd64.deb
     digest: 28686d830a44272e63013aae1e508f0f767ea28c2a4856d6c6724e11b2a6f93e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_amd64.deb
     digest: 5b552cdd40095bd94c6276021dfc5360f2a6289aa94f155ab3ab3daaef341c1d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
     digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_amd64.deb
     digest: f38475bd848c5e0f4481bb11a55779bcf37d263523f5b7a7625511e7202236b0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_amd64.deb
     digest: 178ad33f72e1905c6d777a680fad42295608be7a6f8f95dfe5f2f27dbfcd5505
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_amd64.deb
     digest: a037354a8429c3c32358ee745ab5dfe3d92cc60b74fa68d6355e8b63ce100fcc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pcre2/libpcre2-32-0_10.46-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pcre2/libpcre2-32-0_10.46-1_amd64.deb
     digest: 97811098f7fc09c7cf0f3e1b5bdd9812af8aa5793039e8b678bfeb8d57b9750d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pcre2/libpcre2-dev_10.46-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pcre2/libpcre2-dev_10.46-1_amd64.deb
     digest: f1850c35ce5b42ad77153650ea66f8611b2c171b5b8761870f938795f517920f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pcre2/libpcre2-posix3_10.46-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pcre2/libpcre2-posix3_10.46-1_amd64.deb
     digest: d4e0f487adebdfeb320945153d10ec21f094eb4aea3c806db768ab89f8da86eb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_amd64.deb
     digest: b8f9b921c681e6c08abd8d452489762dc8ec3234e058407757f4f383ba2a01c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_amd64.deb
     digest: e4677f42eb04cd63106e75ef1c008595a5b306129d6fdd58171a4b3732f2aca3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_amd64.deb
     digest: 8d86e3bef4bb2aa5b9a98eab26d7bfc4929e2596808018ab4dcd905d7b045961
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/postgresql-16/libpq5_16.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/postgresql-16/libpq5_16.3-1_amd64.deb
     digest: f458fa7e81f3f405b122df4a87d65d93446476b0e60da81ea8062235513df9eb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
     digest: 8be922fba920a96d098288da4fa5f1d5dfb778b362d7a26ed738014305aa3787
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 55a196ff4bec5823b6a575786527ce5e3986828b51babd9e588bea8a155ccb8c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_amd64.deb
     digest: ab7b2830d58cf362c4f33c7252a7ffe5130893560082eb6a43a9d208e4407e84
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: f38eeba0a1b17444653ec405895b293a58ba9243b19cb4d769b9257b39c8305f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 4e746495d4b45b99d7631e7af5a3c828ad66b07f29ac539d31eab07d5cdf30d7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
     digest: fca05a0b5e2a9e79d70fb282e4fd5be1d8c0e5218bb359e5985c47a3d886905b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
     digest: a7cdf3370adfc03459761b96ea0701a32374981e41d875338cf21f68e32e31fb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 48b849c1cfa4d1c125e3e74712fde44449b82d1069a0e1c9f1bc8a6bd0152a3b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
     digest: 1c3db1f054f82d7c0957edb0e59a084a81a7c3df5c43357f479accbf9df075e5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_amd64.deb
     digest: dbc187ef7ae9fc30a2880002a2cc4bfa132f83dc7c2abff91b480bec6a8fd187
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_amd64.deb
     digest: d754dd297c4bd2b2a93ef7d7bec5b1929a8f06a6b35ded515e01331633d1204d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: a6c55c0cc02b525308a1947845429bb3edf3d59744a3388ea6cac88d6a3ed4a1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: a6c7a015d5f7a2fdffcd889fee78e5da99bf0ad130f47a20133fb39301284949
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 7ac0ebc7a2dae4913cad047b7e50f263060fb78ca4fa5abdb8590d49928ef697
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 6e5e294b19978fc4cd73d026cb49caa0c24203ad4a248b19bdee3501056ab2d1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 36d0443dea97ca2a9a73b29b9cb0b88a12b21e68b1acbce9404b1b969c872486
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 4ab5f10a3b8580b263199414e5967d848ca695227145b18d90f53c4722a79e7a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 1b4aacd3a5e015f4c51a9758b57955af6ecf8b57f724533462d968ce236d6924
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: c62b3954253d2050170c368de79e797ed582d02221f7e84570fa163c22b67279
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: ad8f460c208955b9224a2b1d7aac20105f034dd4065863804b2356b036e79691
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 2b69e5e08781b90e4329ccb163eab3ca9f2d8e89f5d223e327a8311bdcf60c7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_amd64.deb
     digest: 824c7f5ea18c56c178f06c891eb718c939fc0a4d387dc55c048b4b234a21017c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_amd64.deb
     digest: 48df47dc9dab619440be10b81db1a6d75c4e86a6f0b74b98f3d92f6cf97f3894
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_amd64.deb
     digest: ae1f26a30324396caf7f9b2bfe6194610e91d719d9a2b2d53be96426ebb553ef
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: d269d49afcda0e6563e82a86e21b92ede22845692b457b002a88c34410128893
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 80b2796e3d25c6b46c814f49c1c36af5531ab479a83cf16a30b689f3b1e6e69c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: cb774da0434e50790cd507a3fb666938ade62ad638139a2c61e7e5b19d81facd
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 75fd298768c7fda77a2bd83847babb47b3ccddd9381ce16423dee4ff17339182
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 0206b6c4804ba11526a4d4750c4508fbc49a46a3395451442c22df7031c8f333
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: c6edf902bdf5291c0ef4f04910e438bd4a1757c47c33572cbf6a5acd50e26983
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 9536ca32686cc45e95b5e988630552aed8477a9f1100d46441d41191d56d0026
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: f58922086ee84e51a4c0f5a7b6f4c80f8ab7d41566207852f396a1f40b91f987
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 318a26c06b6fe9e83821a2ab57206fe8fdf9ce65345db9b38e2e2cde778c071f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 4439f7a1ac6d6c37fe6c1b281add50298b4c6084b19696f4a0f910155774f257
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 144c2893455bbf7beb309be8b7a160500f5707107272c54b0b5926ead066e7ce
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 9aea6c205086140d0cf5c7ffd7550016ea8e72f10fb9f430cadb3d82ace6b0ae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: a061c61e695cf3b29da3d46106332dc0ed9983ca9114b933cfbc8539b0c82fc8
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 3f24c881d0966a6c0f22a534268157570f8b74bc60de1395775635798ed88b01
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_amd64.deb
     digest: 4e5dc0e41f8c49451b4595e605ddbe74d5cb4fca3100d26b552aa6a0931d575c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_amd64.deb
     digest: 73c0e26ebd541bd02158cf6265fcc55b16b7148f9db0a4130b7d7bb50a83978a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 81daa7ac7482425dadbc91b3e4a0b1d3937bbef908a676ab6387868399f27220
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_amd64.deb
     digest: e0a7e4c340f2cf2a3678f5b66fd7636a1b94628e5095f82c530d7e67393a756e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_amd64.deb
     digest: ee6d7effa7144c000e0c4f735718f3778803c5fe1a164b780d5c8dcc573567a3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 0318d3ff15107f5c3e308712ce30a7112e678f1ecfccc2032079eb271d58bc9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 2c370a18a9c6a42a8283cdc53863769de52431cabd00b196b98608bb82234927
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 992afc0c3df2e0dec237c134b5e5de9fd3f06978aeb1cd0a6ba99a33a8a1c57c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin2_amd64.deb
-    digest: c06568eed5c1bb0163ab9100612d4755bd3bc73cef5c78c9e72cd6816828e0b4
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin3_amd64.deb
+    digest: 960d67e5fdd0b4581676f92e2f76d2bb85ffb6273a675b2433e0fef9aa99105b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin2_amd64.deb
-    digest: 893d6e756b112108101e2b7ce2645a4924afcd55462b96140974a580abee1799
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin3_amd64.deb
+    digest: f858b029456b094fdbd2ee99a376d78be73c015bea9d4bbd6f8add23c722a048
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: f91971028658594b79a6304949a40eeca5a050fca4f33e75fc66f387f5235b81
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_amd64.deb
     digest: b31569eb5340aa263ba7d526406c50d7877c94031bcfe9a6da22da6b794a934a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
     digest: fccec1dfae75e5e95ee0c23f7b705c78e84c9646bbb7e2f929ae1bbfbef6e5a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin8_amd64.deb
-    digest: 1a1fb4b98cc64fd4d31d3640d55902a1085d7af4e80006eb9d074d66ce386f01
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin9_amd64.deb
+    digest: 174c76af4979f20f295af96e9bd87beec3df8c4ee3dcb5a90aaa691cc4a15f81
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin8_amd64.deb
-    digest: f0544b2ada9190e818c5d81a772e181179e6ae37451683a2f8ed9e20546e3055
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin9_amd64.deb
+    digest: 046aa45571b2b05b2d213fc663eeb4bdc15fb79c125baaed4c203313e3a90821
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 6dbeda2bff5ba28e56da3ea7f5930be7c749948288296f8de899e5ff4d4431d6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin8_amd64.deb
-    digest: 63d7a1cbd3a67e93f93ec6656bdff6787f51e506e0291634c85cff9d1656491a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin9_amd64.deb
+    digest: 3e25e1ce0a53a814a3fb0c86c84d253c4307c8bedff3cae691234eb5476bfeaf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 547daa2881ec2cfae38d901ede4cd317f35445b2454c939696aa99eddd7e8853
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_amd64.deb
     digest: 4b74d4425bcb1d23d7763e62cb1c9f2be712d9f92e46542151125ba96d623164
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libr/librist/librist4_0.2.7+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libr/librist/librist4_0.2.7+dfsg-1_amd64.deb
     digest: a1b97e9333948a2fe8001e60d882e7decc9fabb83d5532305f3ae9a2f0473c69
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_amd64.deb
     digest: f7dfdd9e463828cff8e624ceda7f13cc68f2c9d2e72b27dc7e7315e1193b7d92
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libs/libsepol/libsepol-dev_3.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libs/libsepol/libsepol-dev_3.5-2_amd64.deb
     digest: 4a1b7141086a540294dfc0df7eb707f2ef1e57d2a2f4b30f80821164d0f97b7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_amd64.deb
     digest: 7af3357f80d57fdc31a26596f9e93f0218a625929822228d312498cabdcea72e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libs/libsodium/libsodium23_1.0.18-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libs/libsodium/libsodium23_1.0.18-1_amd64.deb
     digest: b16ee914acaaad0cb1c062370f30934b76e401350bd531d169e5838927c4da30
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
     digest: 44381cd9ad35fa6ffa7a0b3e27611011602bb32093efaf0c80117dc9f97a371b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_amd64.deb
     digest: a5b9b34ea8699849e17a2e4c7428f5dabbda217a85ca9f2cc47e4ce6e0d250b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_amd64.deb
     digest: cda4bbbcedb3ddd9b6722acabb811b95d1a6573a60ad7e6fedfbccac843bf8f2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libs/libssh/libssh-4_0.11.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libs/libssh/libssh-4_0.11.3-1_amd64.deb
     digest: a525b7a475d9ef111dd4b9af0baa4eb5a06a15b008b5a9e27f754a5ee091eed7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
     digest: b0e9783da04f53ba8da97660523021322c4477059c63d3684fab283b7f9aef9c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin6_amd64.deb
     digest: 23c5cbb956eacd24e11df263ff700de7557404a6c1309703716efb9eef0d10f5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
     digest: bbaacdcbf341e500cd8fbe0dfb75fc98156b0a5abf94e43105bb5f745c3168dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
     digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/t/tiff/libtiff-dev_4.7.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/t/tiff/libtiff-dev_4.7.1-1_amd64.deb
     digest: b7e8b2a089951068c7a0d9d1fc96f1b7e5d6e64dec48f3d82f727e4cb3f59b45
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/t/tiff/libtiffxx6_4.7.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/t/tiff/libtiffxx6_4.7.1-1_amd64.deb
     digest: 7768a717a7f93d1888403b7a1c875a2774c9b711ea84e8cbf17de9b31c617631
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_amd64.deb
     digest: 1da0a72adec71588a6ac641b6f60ce39aeaeaf6771bcd2386b7dd33ad49b0548
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
     digest: d7c7fffd808cd0b765d2287b98bea752d740994788dbf90de6db4f9710e41162
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/systemd/libudev-dev_255.2-4deepin19_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/systemd/libudev-dev_255.2-4deepin19_amd64.deb
     digest: 35f70a1375dc57938ff3592a62d6cfaa1d497cfc03aa867b1742b289c866930e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libu/libudfread/libudfread0_1.1.2-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libu/libudfread/libudfread0_1.1.2-1_amd64.deb
     digest: 5ebb4a61642a553212842e52f9bcca0bcdf2fa47f95d8d1a4b30d6096dbda8e9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_amd64.deb
     digest: 50a8cfed14d73f5e15fe13de7faae7d05b5e3a5afa79bac1ed373cf8487213a1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_amd64.deb
     digest: 24e268d97e22c4ed71c91201fb5d54f8b4b8689cccd032f11bb4faa1143bae04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwacom/libwacom-dev_1.12-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwacom/libwacom-dev_1.12-1_amd64.deb
     digest: 2e107e0a55003a2c223c792b5d505e566c553c42b0f6acc98f927f1a88bf4c2d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwacom/libwacom2_1.12-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwacom/libwacom2_1.12-1_amd64.deb
     digest: 2e0eb22e108ff3de178a570dcd21ab3d6cc16f6baf94bec37595008786789280
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/w/wayland/libwayland-bin_1.23.1-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/w/wayland/libwayland-bin_1.23.1-3_amd64.deb
     digest: 452bdd1fa61105c0e7a8aed8afbceac7a3c3cc07983ffec146f77581f48ac713
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/w/wayland/libwayland-dev_1.23.1-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/w/wayland/libwayland-dev_1.23.1-3_amd64.deb
     digest: 475c2fc3207e28a3d5c54b81b313b00222fd52042fb2beb3cfe7814dd40bceea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_amd64.deb
     digest: 0c60cd19f18fbd0cf299480c7e7cfcb7451e6b1b05dc8f2d5cae1cd248e4bc5f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_amd64.deb
     digest: 26d6ff4ed6bf1da7fe3eafe2514ef5c04a8792381b35e3bd3745fab1b6347246
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libx11/libx11-dev_1.8.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libx11/libx11-dev_1.8.7-1_amd64.deb
     digest: 93ec6c1345900f791549c12440757ba08e756379278bd6fe5133e6690c544621
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libxau/libxau-dev_1.0.9-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libxau/libxau-dev_1.0.9-1_amd64.deb
     digest: 784b6358825482c6b8e0a5515c1ea33a84e1ae70999df930a75c344a476dbafa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libxcb/libxcb1-dev_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libxcb/libxcb1-dev_1.15-1_amd64.deb
     digest: 981d5049c153139995fa5d28ca1da252bbd5239a25111dc7bc28ab8c556d1b0b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_amd64.deb
     digest: d0b1950a8dfb16ff2f3c6aac1296b508da0f25eef3bc636feed2116f7ba664bb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_amd64.deb
     digest: fd7cb0bb0dc64c7417a6418bdf4d67145947902d5dd668eab4949811b170ee51
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/z/zeromq3/libzmq5_4.3.5-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/z/zeromq3/libzmq5_4.3.5-1_amd64.deb
     digest: 6374362f4defd2e6a454b31a8fe8e407aeb5558c4cacebc6a97a3c9d7f639e18
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_amd64.deb
     digest: 92ec406d537e08271b66dbcf10d5730fff8eee067379c9fce7e74e4c53c6b4c3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
     digest: f7102c09d7ca6cf19598b0901a46799ed935bd3278323121b11360f38dc48c9f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/lsb/lsb-base_11.6_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/lsb/lsb-base_11.6_all.deb
     digest: f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_amd64.deb
     digest: d184d5fd7e340055beee8115e1f28663e539c024ede10773ac03f4ca3f86e343
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb
     digest: fc03b0233080c11aadc3ef81283bcba5ff4904e0591ecf2beda7a4e7157e9975
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
     digest: 848333f2b40b586ecf8f0db2b6127398d0423867e689937c4427ab15570e5581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
     digest: 729d9b051d2dcda0d0bf51fee21d3b685093314a0b2283926f1eb11f937cb04c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/patch/patch_2.8-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/patch/patch_2.8-2_amd64.deb
     digest: a68c27b1c86624c5b6b60668fe0c11f4414134508fd97454a429e4b7211f70fe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb
     digest: e9751c5efad4e9fb2150686bfb82ad13ff8b8f7d00592d3571f70f17a61ba884
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_amd64.deb
     digest: 6d6e880665acf6c1600e779d00259242e7f58e957dda43d760b65df472ddbfbd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pkgconf/pkgconf_1.8.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pkgconf/pkgconf_1.8.1-4_amd64.deb
     digest: 3e8dd26853b621b7b1ef82533bfb3bfa0c9ba07f581df727cb3271e7a35edf33
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
     digest: 4b0fffc886401daa9acfb53e2b190528e3fad37a49b989c4fae6715004fda41e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
     digest: 3f6d07590c1e8957fdc76082f19363f1fa8e5fcf94f7ae1bada4afbab55eb92b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_amd64.deb
     digest: d175f018dbbae1236092a09cceeb89b8686be4a1acdfecbe1b43f30382f97928
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 3650095cac77b7bc99f11c237f73c55261a58be84049debe73d180177b8c13c2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 193d0cd790805e4de5e52be2b8f3265385b9bcea996bef78ac4993f6db0d4992
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 642ae2df2fb1d602328b3120a2a1994a44bc287b425871d57d48327171013124
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: dcdc98ee1686dbbc06ef7cf0931e8c2e1e99a9858b9d69cefcdd99765538e488
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 3f0cd33c4f11641a059918ad007794caf8b8e0476b9ec0ef338973e51be2e26f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: d54e7797c282b0801e714bb3f366ad7d5e45d4b60ed56e65479c6f9804156e74
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 4188bc7f888b8af599c9ba86b2dde2deac914ada44a4d0642643cb5e095f594d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: d9644e9dcbc8f947fa63244405ef49bdf1290f29eaa77f32fb94a4f4d6aa07f8
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: d1dd97852b32905722f0e502b9ebca33076850baa978ed48b6630ff7799831b6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: bc0d4dcc7728fcd116cef421446f6bc5a2351e4c53c09c1cfe59454b9eebf354
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 6bc99ad428297c0e00769f564d98aa47f2c03a4c613e5b2ee38ff7e1d0520025
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 3e548303825c991635a8c36f00579fc94b615ccbc29c951985161078d7b57ab1
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: b179589ab0123be97fd96c0a132aafd28dbebf3115bbac4a3e52cf2d58b34db8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: db06883a729cce76bf6b86be68b625cb0d3f5d1f7eb5fcbace1ccb40e59c91b5
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 6dc568b3b94ddfde4306eba456c4b1de680547c49c8f553bde61528a4cec0259
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 742588b9264ee54dd4b6735b4dbf9069dfb8e25fab22068eb822f8a90fe04a46
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 982d93159b83c957db897dc6510cd4b49f7ba1f3a1605b57891f0e4b1f92e716
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 1b4d670bf8331982f1908d16e46f8521552e311519d10d86945b1a2f67935e18
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 8250ac99d0292cf182a88e694ae79da94b90252487c622c0e69dd6a0122dd5bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_amd64.deb
     digest: e3ab20d4d1cf4ee712ac3e5624e78369d8cb5bdae57f830111ca244abbe9b4fb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: b8f671a38688afa1bfd7d93c1900f284f546b09c60c2452cb460d7e5569f1bdd
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 4ec906d0b86f6ee416a0f7d989fa994bf29dc109fc2666ae5a109584a767cf89
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_amd64.deb
     digest: 3c7e5c7b9970e4d65a36a8480be3572faf88247c25e6885c46232042fb131cbf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_amd64.deb
     digest: f97ace68363e7bacbb9ccbea0e581efc04fa2bbca15a0f520e8ee2fe84ddea53
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 521139891eea3b4d1c33963deafd837dc9ee6d607fa20a23e3da65ee2b4ec8d3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 9c663e6e7c4a2492a3313e19e311ca5d7579b03cf3411ed0a821400424fe8e3d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: e6f714227289c2147b9e0a06256ffbd1ab0b4cea5a9c8fd869289249c608fc40
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 0cbcbaffa069e368c784bd539dae929c71183fc2cbd3fafc1d276442ece2f0c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 538bd65bfe75cc3ee204032965cb0a8ba8d9819465e948201868c0acf4503de2
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 8f10466a03ec139a920c6bb7544a2bcdf9cd7e2370012592ea6cd84079a2f1f3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 18a2f9c2e2e2ed7fed356602edd52bc0c33c9e928c0157989c20b96f74494479
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 06d5a43c2ab84ff3a763e005362c105738d5284aa59346a275718161568aac22
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.37_amd64.deb
-    digest: 0ef771aae1ebf4aa0312b270b77c62ade6d4c0b5494fd34cebe3b390718bc3d4
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.41_amd64.deb
+    digest: b16e4a10df2b93f6b2bb0b30a69938598b6ad6729c3846b6617ee2762e70cdbd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 9e603fc20b2b47bb238dfd9d94f73cef9b7b94f567afa9feddbc754c6712658c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 054403819848ca761587f77e239787a33f3ab894f5c6123176e633228503e79f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: ca43a20e8b8bb2150ffb27d41ded38ddff12195aa3d5b3fd7c73e910cf009daa
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: c350bbef6907ddcc08b22cbf73e5b03e8dfa245c3e3a31269e44020e479cd7a3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 766e4e9675ce92ddd5ce65bb99fb17babade7d56a1a1d39bd3c7e61813d61a6b
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: fdc3d77c6eb4c0eaeedfbadbb219b8ec3938e1bc65d3a4826218abd6379f9db6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: a84a3c5d187cba95dc2952d697b8e9747e43c3b58fcfdbde6c08ba91b6c382e9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 5732c11fa805290bccf0f9ac2e8559051a49d6b720a2399b5d2296e305571e9d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: de620ec32a60fa4dae68a988328083c7b98793afcc42110009401205b100387f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: aeaa6ab4227e0c4d6ef260f17603d97a753c23fde053162f3c04ad87b82aa94e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 4941c8bb2f3ddd5022ede266ed294a21fdd235ce95ee96ba056268972091f54a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 685d78ad540501680143b595c317c89572482b803602019d9c11d0903b857dba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 291bf32e9ba9f775291ee7d2d8d4b7526fcae6a3cb8d95188dc0f75597e45cd5
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: af5bd555af5790eaf027ace9ebea6bf39360ee7cb4d15d29a7af09f45f74472e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 398c6bf2fc52f590262402b4801ec0c3dd0ce62a1add1cadc07789a64486a2aa
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 6e61d9ca9df23b7d37e20b38c6cf8d6f29802d2aa44207ea04d7177ecad301e3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 190158cba91807284055a08222b8574411e267f05bb135c2463eae20a260ef33
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 2e5b49e0df262e694f9cba4025de5f553ff949694576b33d9691e32bf97a6768
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 5dc0ae7a825f9fb2c34d524d031e0743755569b7a6c608c60cd436fb08b6d908
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 828779a51bed08c1e512fde3780573bcb170c27eb52a8128144eca8b5a108762
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 7f921346273a0cecf18a27b99431b493dfc1188505fd0a2e98dee6ef4968c255
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 5320e2ecc73d82da7b559b8d14d40b3dee1f5169442e966fa5a26417b4d73a31
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_amd64.deb
     digest: 172fd1eead6e3bff1e2c19e5b6a42a6979ccb7600b2d7ac2a81cf404a1c351b1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 6345b7d1d765d548f8a5ec3af7d764ef71ba382f238c420b0cce90cba4d4e9a8
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 1f2a3cf8df720629f23dd82f581cc96abceea3edc1599e586cffe21808e721a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 62ac1b64bc73421748409a73972f8775ee4c94a52989100d0f264f6660e09e4c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 2b30c0354c6653cc6cac2402d006cfaa65d0a8d5e29dd5e5532bd46d3f7a7e7a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_amd64.deb
     digest: 470f392ceedbbb90b4f889aff6987106e864db604833e0fa3bddd61baa93f3ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin8_amd64.deb
-    digest: 96920d01282315fb3f99b3fe4cf3d5ec2c7cb64e0a28b20c44128d0990adbad3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin9_amd64.deb
+    digest: 84c8580bc0e796926a3b1b0e1003ae4504844ac201ad217ae08862258429a833
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin8_amd64.deb
-    digest: 645bbfdd31ab123370895c7fd4eed44d17cd945681c77881af89fc119a71856e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin9_amd64.deb
+    digest: 380708603878ef7b47588c5ac1774466a52d7c614bed6818e20daae1c34c3aad
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: bf89838d941554aa33a82403893335a9654d7b7423731159ae0bc8b5b3b4e4ec
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 1e0df601de27fee10c046bd5b497a723639176dd2a0d225531480e9ca418c576
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_amd64.deb
     digest: a61f1a75f31b6b3ea46551a2801de97d83282870c57ca69f7d916ecac63489ea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 557a063f8555b0c5f19f3f5857a1252ef798e3ef900a651c2eef9dc1c255bc78
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 5638a78999262aa08fb911ecfe8d72d82f0daee801624ebf16c5abd70bfc6f90
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 1a30d7387e949a9e2c72e14fdce4379d0ff8d1afedb22132d3f4a921b2d20754
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 7d2deb0c5aad1de440220c697b092bcca41c3ed77ea3eb1c4e4e7925bca2d9fd
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 6f47aaf3b175e8dcd28d9b16325287278f3218f688aa3de38499ad3c49732b18
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 8337b9641a2da124be8869b52ba14f023fa92d168afb2c33d0aede82fe567829
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 044efe5f29c58b13fe15e1e2018f8412d1a5f37c40679d1e51a2401899e4498b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 5ae031ed41159d621df92af9b4987162db5b3807e67e8b84f24a7c53db65a56c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 6fd46795b047a6b61f21e98c9c20992deee2f2c3c02ffe600a56b75d1219dd65
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
     digest: 9e89f44e0c10a9e499487387a568a1690e46d77078969070fc0e1368a49180c6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 861b548892972e2b92998fc2ef7c1f24ee950c7394408674348a735a79023f5c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_amd64.deb
     digest: 9673c22b10da7c5895a4d3697b970bc2e5217fe09a468eb79760bb5e03c62959
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
     digest: 9bb6be934533f5c98bb8f7b1f960741a2897824cf504ea93f80b9fc2b102fc34
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_amd64.deb
     digest: e49d551b49772f35ea9a4c524e58b523dea5c665b6ad96383da54a4ee9c7058d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: 398e946054f57533c9bf2ca1b1868b2ce898194c3421798de68d596e77a8b57a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: a89710c6be57f6df9dbe980c6992423d17a0ada4b4d76006794a9a3b969d8d11
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin10_amd64.deb
-    digest: d670e09f83d22cc36281feabb36b8695220593a7f53b278b70135495c3c683d8
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin11_amd64.deb
+    digest: 2108c70067d7ed9262f6de1a73213b064eeebd6cae6e0f61741cddf17f572459
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 3fa6c61d5929042d57cc8c68816ed94701f1f995f5a11d961835c18526bd64cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_amd64.deb
     digest: 2405851738c3c42a35667a20efebc0830238f8e1cff38775dfa28edce61981cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_amd64.deb
     digest: 2469decd9f0021993e7c4f3df79c7eaef7257cdb9a99ce1f208a57446dcaed0c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_amd64.deb
     digest: dcf8a050f6f90c36f7c5a1291d6d6b6a83b2c80105f63352badb3be8dabd0ac4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin2_amd64.deb
-    digest: 30fc576ab21040ed3f612d00bf940be4bfc8826a8b3e975aa09aedd8fd3e3afb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin3_amd64.deb
+    digest: 90b94fe6087085878ef33e1a00d5a3a0de28ddd5126831c000383489ea365495
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin2_amd64.deb
-    digest: 3abe59653361823d7ea1d4c3e22216c2458e519058633a5f3156d465cd7dc842
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin3_amd64.deb
+    digest: e633a4faff2891888972e1f1b37e3111f02d717ff55c5a3b7294a9e4ddb6de51
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_amd64.deb
     digest: bd393b38678a73c27c0d501fa9fb8014a65719760cb04a3acd813c0fd4d6ed5e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_amd64.deb
     digest: e05c22f70ce1370504ba6f537748e799a20da4170718199080beacc63071fbd4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_amd64.deb
     digest: 54037eb0f4e26bde01e38ce19d70514de69419b93d1fa5879502aca6a9eb0838
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
     digest: dbfa88dae0e66fa60e6558fa80242bb78be8dec5b37ea449f85826b1b48cf25c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin8_amd64.deb
-    digest: 04d4cf6898f22cac7c8b69561bdff7ba70f757685b34f480c579f8109baf9cd3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin9_amd64.deb
+    digest: 4b48e5acfc000ca1036accd137c30664053be4e4d0463d9701c7faade332086e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin8_amd64.deb
-    digest: 6fe1d23aafb2712ff7f69d71fb6828959552da5d747381e37d29af69f36bf73f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin9_amd64.deb
+    digest: 95583adefac8c0bf36c679e1b32da93e2085ae60bdff0190eeccb137c52b7618
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin8_amd64.deb
-    digest: 606688a38f687d51d726a0b1e42b560c5d31b4e49ef95940f3612565693e6203
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin9_amd64.deb
+    digest: a67efdf9e61737a187826d0cec236e992a65075acc43b721705a2bc743de3ba7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin8_amd64.deb
-    digest: 64755f2c995b174e9e40a5a3d27ff7a20707e02b6135ca8bfcb04672ae7a3524
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin9_amd64.deb
+    digest: 48345dd84d7a5e0fa9dc479c7adbaf08c97be5d29b967e20b2a2ec8e69145b8f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
     digest: e70bbe5b35aa1009f8d3e8d58634052977864bad1d854230add6758ef238b1bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_amd64.deb
     digest: d9813a73176fa51ea5341b97cee8ae674c106b422737ebb819107e66068aa25b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
+    digest: aae8ac2b6d3198d297d430cdb97e556365be2ff46d06525008ce071d97ac69c7
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/uos-license-content/uos-license-content_2.0.5_amd64.deb
+    digest: 9cba9bafa6f9b2e5c47246173a3dbd6138e1b05c6a0254473f08136b5d9e0b9b
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_amd64.deb
     digest: 15c9b33ab745cce30a6d51d8af8f0d3ab80e68af8dd21a416e16e60c2af359fe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
     digest: 82bff9dab1d74e30bdbc6130f94d1bd361c3c1d3cdad660bd92e5b730c4cba7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
     digest: 6d5bf0445a25257bc75a612224498ecddda2fa56edc8d17af5c4bdd2713edd4b

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 25.2.2.4
+  version: 25.2.2.5
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -13,7 +13,7 @@ build: |
   bash -e build.bash
 
 sources:
-  # linglong:gen_deb_source sources loong64 http://10.20.64.92:8080/crimson_runtime/stable_20260415 stable main
+  # linglong:gen_deb_source sources loong64 http://10.20.64.92:8080/crimson_runtime/stable_20260519_1 stable main
   # source package qt6-base
   # linglong:gen_deb_source install libqt6concurrent6
   # linglong:gen_deb_source install libqt6core6
@@ -176,834 +176,836 @@ sources:
   # linglong:gen_deb_source install libfcitx5-qt6-dev
   # source package deepin-shortcut-viewer
   # linglong:gen_deb_source install deepin-shortcut-viewer
+  # source package uos-license-content
+  # linglong:gen_deb_source install uos-license-content
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_loong64.deb
     digest: eb1f44a7f8d9c71c545fe6dbbf2b58675c2e5f18dfd14733941a2644b8908c37
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/b/binutils/binutils-loongarch64-linux-gnu_2.41-6deepin10_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/b/binutils/binutils-loongarch64-linux-gnu_2.41-6deepin10_loong64.deb
     digest: 7bc0dd4189e823f2f295b61c4d3132748af53beee8cfedaec571fe9023593b0b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dbus-broker/dbus-broker_29-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dbus-broker/dbus-broker_29-3_loong64.deb
     digest: c32fa99bec894b1be78e1a8a8c5ac0206a3962b750aa9338387297e240b9db71
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt5integration/dde-qt6integration_6.7.34_loong64.deb
-    digest: 8903ede7339bdf4816b30f58d9acd07fd575da03176840f2d3da59bb84ec6632
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt5integration/dde-qt6integration_6.7.41_loong64.deb
+    digest: 34760b8492cb48d684a7e18c8869c15a7368fa82f0f0624893e6530b35f6f9b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.37_loong64.deb
-    digest: e691c8aeb1e41f6a5545e4f9c24966f882d46fd62695d95422aaccc2e68a9c40
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.41_loong64.deb
+    digest: 32579b69611a449da495ac3211e879750f9eb92c4756eb224925edde1f6e6c54
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_loong64.deb
     digest: 60d20d41533b1a178f135352f161a1195e8dc2e105a3c0a4bf063aee66054f6e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
     digest: 377acca7fcea64458b6d0ccbbdf8773e6a23d0219739747d6a2255c6fc43cfeb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dpkg/dpkg-dev_1.22.6deepin7_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dpkg/dpkg-dev_1.22.6deepin7_all.deb
     digest: 4c292d48c0900e0b3939322c8bc7aeba358873c73f608f5f680de8e120d387de
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.37_loong64.deb
-    digest: 9f0b695352b3df11f79824228260f3a5e0fd96dc198b32d4d06499060f3f661a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.41_loong64.deb
+    digest: 102b80a558163bbe56d9248955ea4b3ebc72f07b823285340b752380c9879f40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.8-2deepin3+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.8-2deepin3+rb1_loong64.deb
     digest: 6f6d366a88a14dcaaafa391359ac6d1383e48ea77e43501c499f331e851c7ac3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
     digest: fafd08c872d1279aa0bde2e0bdf40a57721961934c0593352b6a2c551aa232a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
     digest: ef932bad267f9d4d49c0c376ae1d0fc1a9b595054f8450d42b2a0d6621bc7084
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_loong64.deb
     digest: df1346b7d3f97770fe21c1d05024d3d9583cfd1d4dd3da3036f8a306419eb1a1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/gcc-13/libatomic1_13.2.0-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/gcc-13/libatomic1_13.2.0-3deepin4_loong64.deb
     digest: 1ed85dc548b54f63267a5fb8c81b8d90638df81de8bcca7448e087f994b31bc5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin6_loong64.deb
     digest: 9f77415b3db88a610f862b0bab7d06a8195de1a6a1cee3de9994d51e08599efd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
     digest: 43c9bedf808d5c2b85351f73dab25e81c5674c499c293be875ac5250c4b8cca0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_loong64.deb
     digest: b8c86c20ac3f591b298fafc9d94b91f81df48f1b59a65493933e79dce235ce07
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_loong64.deb
     digest: b28910a92aece870792abb3b969c20947e0a9dfeed0957b8207c49ef97766b8e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/b/brotli/libbrotli-dev_1.1.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/b/brotli/libbrotli-dev_1.1.0-2_loong64.deb
     digest: c2388059363813c7ad5e42d91f514b1e93e3dd07432634eca0a6814e2d7edc10
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_loong64.deb
     digest: b073876e60d9f9ba41ff9f984d0895c37684272da7ea5389b2ceb85598e3154a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/capstone/libcapstone5_5.0.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/capstone/libcapstone5_5.0.3-1_loong64.deb
     digest: 9fc4dad13f7d8cd45e037e5f4bbc7aaf446e76cb583ef9fcab6c5618c4e5d6c9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_loong64.deb
     digest: 23c1612c4842c5ea3315b25e15d859301a5f925f439fc377b3b989d1473d142c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_loong64.deb
     digest: 970155ff2e9d993e4daf74f3c3d1189b5ba3115603bd3e458b80aee42255a9a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin6_loong64.deb
     digest: 22828933cdb2d05b9c9a5819e1f469181f8ba945f6f2c1902120366a8f38865f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin6_loong64.deb
     digest: 74ee05e00c36d5e52f12505f9b6b6133ebeb538361827a54cfabd0ae6875b5cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/cups/libcups2-dev_2.4.2-5deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/cups/libcups2-dev_2.4.2-5deepin4_loong64.deb
     digest: e67cb3d15a93da6435d973b2ff3cdce91cccda3f6ffe9df1a5a9daa78f63b7bd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin4_loong64.deb
     digest: 0c988edc38ee598597fcec5a7b5db10cab8b96c31957212c787eecf80e1d9c69
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_loong64.deb
     digest: 6d218959ede7fd5ad4fde3c25dc2c26f113d1e07c487d344a7678c29b9ce0dfa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
     digest: 1cb1deef108f4163f884f564e9fcfd429adc315e9509c30ff3bcf936824ac543
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin7_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin7_all.deb
     digest: 04549bfa8689f8ebc2759529bd4c8acb8abca185cf68668033352ef9b546e57a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcore/libdtk6core-bin_6.7.34_loong64.deb
-    digest: 56e7ca81587b5fd598df7bba6edfe6e65e31cc8cea5f843c271d9e6c0e1265d2
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcore/libdtk6core-bin_6.7.41_loong64.deb
+    digest: e34e249f223ec5d22addcb45dc15c8fe70c6246a7cf5c1ad68494a2a8f6dc2f9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcore/libdtk6core-dev_6.7.34_loong64.deb
-    digest: 5445361832cffab25b3a01e84ac0f01e87fef06948f8d2602829f1eb32614c94
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcore/libdtk6core-dev_6.7.41_loong64.deb
+    digest: ffe184039f48537ab39d38df5034a49de7c7795b3f79b1f50dacbd1276451947
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcore/libdtk6core_6.7.34_loong64.deb
-    digest: f4b93e18145484728476f0888bd51d94331ececc0d08a0864f818f5670bba91d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcore/libdtk6core_6.7.41_loong64.deb
+    digest: 7ca5c044175411d55b1619944944a79defd3d2f89b4cd36c3d53512424333ce7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.37_loong64.deb
-    digest: 6516b7406d1785a97e408543e797ad2a1164c89ee4bc45844d503024a1dad34d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.41_loong64.deb
+    digest: 1886f7eb2f4dd35e81543d88c1a0ab1b113821f0efd37ac644a3cd0e2902318d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.37_loong64.deb
-    digest: a724667ab1ce94c2074982b82121a1561a8dd50b8030d9d29b5b341149dd6478
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.41_loong64.deb
+    digest: 322d2dfcc8f941e118c157a216f0bcfb9cc6be428b41bc94227d4ea8489d624f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkgui/libdtk6gui-bin_6.7.34_loong64.deb
-    digest: 6d618d323b1c8c0bf19984666764697f6a15e8a0aa0237eb56b5febdaf044c4b
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkgui/libdtk6gui-bin_6.7.41_loong64.deb
+    digest: 727d9b92c3acbe01b19d1bf346b315bf9c070b9a414194350480e974f3cfedd0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkgui/libdtk6gui-dev_6.7.34_loong64.deb
-    digest: da5cf16e825231d929719f4de47b734126863f711528e903835e0acbd9eeb403
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkgui/libdtk6gui-dev_6.7.41_loong64.deb
+    digest: c6c76f2487e158d15c0bad18fbfb9dd7e1497558109516503099d418cb35fe66
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkgui/libdtk6gui_6.7.34_loong64.deb
-    digest: b4fca6f540c0814b5d2b532441982621847e8e41bfcc508b0806fa4c878aae11
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkgui/libdtk6gui_6.7.41_loong64.deb
+    digest: b25f109a16fe9c45c3b36fe8bdc638dd70169accb543cf82eb0c7320ffbe0668
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtklog/libdtk6log-dev_6.7.38_loong64.deb
-    digest: adf1f8c8b9b0f1cfc4220f8e37b8c1159ae1091ddd17907c111759893e80868e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtklog/libdtk6log-dev_6.7.41_loong64.deb
+    digest: 61ad8437ee0c5a23a62628371f7c49b4755c33651aeccb3ca8559f45879a0fa8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtklog/libdtk6log_6.7.38_loong64.deb
-    digest: 711bf34e7ffdf57aa695ed3acad596da4af11219d515faa3f6d3b069a1c331ae
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtklog/libdtk6log_6.7.41_loong64.deb
+    digest: aa5379baee608da2329d741ce155034bfd719420c277ed4b806e3e75b46fedf7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.37_loong64.deb
-    digest: 4c178b1892fd168e63a4b0d95b2d5430ed7614a48df6bc09843cdf864530f13b
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.41_loong64.deb
+    digest: efafbd3c9ef8beda3c13e719b5771b6fad17f1c8fd9014b0b54c57f4d4ab6c35
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.37_loong64.deb
-    digest: 0d5350d1737e3c45541e8887fb2d65692025a51f71f074dc9eb61523c86ee07e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.41_loong64.deb
+    digest: 3cc7ff7e0c2672ce0a6b9049c4484649dd686f5eebcdf7e0f3b693c1d964cf40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkwidget/libdtk6widget_6.7.37_loong64.deb
-    digest: 6ae565024e15dabccce6c03ea8e25ddc193684a07d50633fb145adc019043af5
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkwidget/libdtk6widget_6.7.41_loong64.deb
+    digest: 015398c73e95031a240f1ee0680299b039261da8ea49de42c6df5969ce130b92
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.38_loong64.deb
-    digest: de19cedda94e43acb2a9b124b99e315d03a783bfc05be1ae3917d12f4e98a128
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.41_loong64.deb
+    digest: 9533d0ff6111fb84e807b5604826130b89d1857ba5a677a447e93cfbf3c02a49
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkcommon/libdtkdata_6.7.38_loong64.deb
-    digest: ec899fafd0d8e6ef485aa7bcca2acfc617cf6046975a65b2d9484d95992faf0d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkcommon/libdtkdata_6.7.41_loong64.deb
+    digest: af201a2115de099871c69b8ed91b726d48da4b3a1b5400fc4b29dad308b16d86
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_loong64.deb
     digest: 1bb14f1d3b2a10316e1db8b888585b1486789cf2b060861e0281178dcd75b828
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_loong64.deb
     digest: f2f047f2363dda33826f748756c5b1c8a2bf809c981a66509876eb150583b278
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/e/expat/libexpat1-dev_2.7.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/e/expat/libexpat1-dev_2.7.3-1_loong64.deb
     digest: 9215174c32f1475b604d4b411289436b07cd044894ccc37749767df1c0a23073
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_loong64.deb
     digest: 1247f90fa5006593b184ecd8ab58a9f3f1d9d9a38c97b67fefeb2ba0122e43f9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.8-2deepin3+rb1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.8-2deepin3+rb1_all.deb
     digest: c5323498567c4b1fd58c620d024a153dc9ed17de13291d25e41f89a214007b62
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.8-2deepin3+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.8-2deepin3+rb1_loong64.deb
     digest: 51fb3e3ec638f8df62f6962416d35e691439ef6ac73394f6712d04c3f71e882c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.8-2deepin3+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.8-2deepin3+rb1_loong64.deb
     digest: a70c409534b6b5848f5f67047db03672713983354f4fd8d61c858cb617c9a278
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fcitx5/libfcitx5utils2_5.1.11-2deepin13_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fcitx5/libfcitx5utils2_5.1.11-2deepin13_loong64.deb
     digest: 0ddbbe1856eccd7de20d402dcf63e8f11ca232b396677abbedd4f37f5ee6be81
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
     digest: 864ef36cd80bc0a9fadbdafca5a5ef05ff92458f945bc1c20753d7635d8f17b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/flite/libflite1_2.2-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/flite/libflite1_2.2-6_loong64.deb
     digest: 89927d11c271631ca816010e3825c066645c90621bc386f4dea59fbcc10fa51f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_loong64.deb
     digest: 58d05c9c6162bddfa086ae65bb7f937b94ca237eac4819cc4c614e67516fac1e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_loong64.deb
     digest: ae8860a596b6ef0831f0c600efca87de921427e30b2b706c6ba682ddbaa624b1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1_loong64.deb
     digest: acb0c01cf1db9cd8abf2ba2fb1deea3f6c52e90a471d0cba26e403d9fca7c292
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_loong64.deb
     digest: 02f892b6d38643410cd753637657b9803eb718268927eec5232e68045e81d13c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_loong64.deb
     digest: 37a693f96d02d97be01c45d972836cbaaac0b9a5043174a04b2e2eeff251b30d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_loong64.deb
     digest: c7351415720634d89b5ddf7e809d78b458be23d09cf32365e14a72141d6d20c1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_loong64.deb
     digest: 1828aa1e6fe842d0713e1ae545f874d2335ab0c683638eb5bb594dd76037cd87
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_loong64.deb
     digest: 260b85824035f054f7e25e2b142ee5397c28953f77f463276203b0e5ed8d9bde
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_loong64.deb
     digest: 03512d70fb50bc97266e9f14dd56fc5577d455aed40072f0f2794056bdd6ac28
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.6-1_loong64.deb
     digest: fdeec611d25b27a7474597c7de734151bb846244170573160c521f64e4d4ad72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_loong64.deb
     digest: 5930cfa21617d8103fad46534ba6d07b3930e28a3606600755a076d3eb95319b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_loong64.deb
     digest: 1c2e9030c9a558915577dbf8047628b212c9b48c175709b244dfa794feaccfd2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_loong64.deb
     digest: eb28d4bec657f7273f965bde361caca747436978ff2b8dfda5bb4ce292c8868c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_loong64.deb
     digest: 0fff2ff2f3f962bcc63f9d7379995197a1727ce30a91f908ea72a3fa662a6b51
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_loong64.deb
     digest: 6d985129e0600d7fe4a411a39bfadf4c73f8563ac1604635d19fda6a9cfc111e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_loong64.deb
     digest: f8251fc25fdbcef6b938b6be532237f63c3dff78dd83b1d3ff665748685f7f4b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_loong64.deb
     digest: 0c3b4ccc6927abdfddb2d909ca139fbbf1c5e81ccfdba90c1ffcce9f460d4cb7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_loong64.deb
     digest: 152658aba54e2f163ba19c0fe53aa7666e1c6907eda79433f1ec38240a9670b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_loong64.deb
     digest: 342808c163f19bfdfdb7f36cf51acce6401aa2c0df6fd5695d0b3a9f2731bd9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_loong64.deb
     digest: c0a9c5a24ac81fd6e5641d36d47600df17b732fe3a5c024753da8e32679a1447
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_loong64.deb
     digest: 6b486a85ac27b4001d13fb43838047f46ea84c3b97baa48d0ede572ccd47817f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_loong64.deb
     digest: 3ae2965f4f532a1dfc813c0d9ba0461219093f4f0ab50c9f3ca77ba99d71cf34
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_loong64.deb
     digest: 53c2272267e61ea69f67973a7a43374ac2ae02be3adaf20f6231b7cf274a766a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_loong64.deb
     digest: 8179fb6587d2de06e44f88785a1a3a530b8b8317d17c0dd4a4878505f6eb30cf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/md4c/libmd4c0_0.4.8-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/md4c/libmd4c0_0.4.8-1_loong64.deb
     digest: 38b04a9c6431d337342ef954a98ddc75b6ea0da7b17d321cf5f4ba17e73d9dea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_loong64.deb
     digest: 501c91fa0ba7cc9f6bceff658ffdba2323039a590719a2030f2dd37266d296aa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_loong64.deb
     digest: b6a33875c9e10005da90db18aadaa4f044f4b694ccfe0b69973a41e881d4c104
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mpg123/libmpg123-0_1.32.8-1deepin1_loong64.deb
-    digest: f03a7545dff01e921e9dbcb683464188c28cd289d557af0778efbb9962f93db2
-  - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_loong64.deb
     digest: 9b74501e7c7e6f5d5708bfb897a6710f2144da4806717be60cadb34d2e180353
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mtdev/libmtdev1_1.1.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mtdev/libmtdev1_1.1.6-1_loong64.deb
     digest: 4a5019080a0454a1380d3353dbc52b5bfebd3ad8f4c210425beeef8b6e5113e8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_loong64.deb
     digest: b8ccd5bf943ded55cccdc92d59c8abb35a1fb65fc3425ebe35670d37b7bdad6f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
     digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_loong64.deb
     digest: 2edcd978231e1d513566ace5c07cc11449586130e0e9b8d5bc126d8a56f8e93f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_loong64.deb
     digest: cd4ffaeb85402fdee4cd618e5d95b20857b2eb83f25d6109f8026b714b4af470
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_loong64.deb
     digest: d5f7b919880e85ef999377610d15bc712151a6ae5b5aaf9752cc59d21923992f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pcre2/libpcre2-32-0_10.46-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pcre2/libpcre2-32-0_10.46-1_loong64.deb
     digest: 2db80a8bfa1f9619374622e0e01a9ea79ba3d2e886b0347a078889c73f969b38
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pcre2/libpcre2-dev_10.46-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pcre2/libpcre2-dev_10.46-1_loong64.deb
     digest: 6ea6b84b6b95885e921a2eb737bc9482caccfdcc42c9af8661f2de7e06c3f4ae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pcre2/libpcre2-posix3_10.46-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pcre2/libpcre2-posix3_10.46-1_loong64.deb
     digest: 58accb378abd0821d37bed2a8185059f72a05e1174c84ec5424ce3f4118188fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_loong64.deb
     digest: 9b68dc19b458a678ae21f5eec1f27f011f0c8da502cf3cf234b5cf4f8e2b093d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_loong64.deb
     digest: 7fa4ed870a512323dc2bdebb32e85ab5c08036153b042a932beec468b3ba6089
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_loong64.deb
     digest: e4ec70f1232bf8277e218069968f1504e1324ee03260852234fe852a687a0fa6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/postgresql-16/libpq5_16.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/postgresql-16/libpq5_16.3-1_loong64.deb
     digest: 2797807f5da6690de1c2dca5caeb64d6ebe42e21a98eb07d04c5a117b7c1a6ba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
     digest: 9d68b88d2e9de4c313b75ec6ebd8df51105856bf8998470dc7faf770308ddc40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: d7e2c48549363ce6b2d199b6bd666ac75adf950e3c38adfea530b856dde6d90f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_loong64.deb
     digest: 0516b6c29f4313bb30f9cf7858cf93c4d1ffc237a967eb65b3f0d5b943d83d7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 7128ee456a1ed6374acd7e0027198e963f437d37a58c7729daac8b66bbf3e59c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: c2c022326e4bae1ff2c9158843dc63dde951352d27afd729e51093e3e8debbad
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
     digest: eb6a664507e891d69db263120e88b82bab4cfa104a39a28fe772d8beeeac21fa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
     digest: 82be98a5406a45ff7c0f16ba2015be9bbf3a269599233ac7fb25f28407b8ac07
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: ca54b35137c523f102931c385bd27ea400b567135ada770c5a44356a885a9874
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
     digest: 0c68f46baa7a14cf0ff955d04931ae6db3a6a991e4efa546eac8b0af5000e3d0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_loong64.deb
     digest: 50cfc130b9f7bbc24dc0eee4ad75bd15dff40b9f126942ec1010f6e85955e112
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_loong64.deb
     digest: 84bb00e7144d357bb9f52720eba503deadc3939f34cd4f1431d8abc6c9181194
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 61af475b7d0faffe02ce7d96b868c825dbdb30abc5b4b613d5244ed6cdee01d4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 0b541fa8b533975959f62a06c3abe11da05db8fa461aa5f1da535ff72985c173
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 66b1407f06d1f3bd44fc40e16b5a0aff4f9ae1bda6fff8740337f0692a3e55ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 53a045a00eeac608d078ec94f3c0fbaf040b4a14933659088cb550ee2f72c30a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 9573f88251cb27acc74365e6c459c5714eea0f978c0763522086dd8569c65f64
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: ca199de10dff716f18ef311b88cb82c5a762263a7ab5ba816939d519ea958135
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 19e26eee39bc6aa772eb1e398a155a365a71081062c35eeb8f32c239a35d5511
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 724f78f71b936a7f0919ad7e683c82ca1a9b5d2e66655c43931d282ee47a7c5d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: e329ce78829ee64cb21e7e1cb17d338ee8695c38a9a28934cc3cdad63dab0c2c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 76a94967a1d99d03c9dbef9766ca61bcc81cdecb3b8d42e56d438cdd5d8cf354
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_loong64.deb
     digest: 9775d45a33e9a2b23cafebe7975e731d477020d65cd5044c722b6918c271abd5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_loong64.deb
     digest: c2582a775b4bcef766cb710c214e928d3acdb33584129447ddf2200956fd1325
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_loong64.deb
     digest: 990ac1a932968384f8f0bbfca0fbb20e11ad7dee53a29a5e425beb8c83cbdb7e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 65ba876fe75076a3e654f32b4e39072f73cc79c569c830b15030483c4ff7a4eb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 8785e2c83381f3af791a1a98f722cd1b8ecb3a7413f7e2acc5e6f981bbe0329c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 53723157a61d34e3ceb28e6d2a9888e17a339263fec19e65fc06bbbdaf48be15
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 4f3b075cb20dfc30980d52e9ba573506eeff09ec9c5f0b6572fd4a5b27d4ed9a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 4314c8da136ec7cbee6428f751ab13e836d73d5e60e508fd32f3482738a33046
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 92c1259194bf04de719e2943745a2518766652a923226bc71c0397567d6c5eac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 5d578931f95a5d91136146bc7877070ae090b19e3f3b8a537877f7d5162457a5
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 67519d24d79c1f0671a87bde7702bb2173f6efdbe62f113f437d2e2b0e9ac84f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 7f9a2040ccaebd78079002d7ec43d8712a086fcbfefed4f740c48b9fd457f492
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 4fdeb9b9e47841780c4e2a4f2fd76b064d28185b374672e8de00d6973e0b8eb9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: e99ca0467e7d2f00f99ad97eb70a3c1fbaeae9aeb7fc6ac918bb54496085d108
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: bd32ab1a9ee79384f11337c29311118da8939535c2b7188ac96c8008a20f4c2e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: d67020ba6a847b1b48f19c85717541f22b13854d20526ad87433224dc65d8a50
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: c3c5f25f65b9eedb6139102cf2712bdb13c24d4f804b997d0d25cffde87ea7dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_loong64.deb
     digest: cec7d316516b54ca0babda908001f58c1055f8af78022528d6fe3868f6f90635
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_loong64.deb
     digest: 071bc2779dd4d67d41c836c3df87c7cf10e50ad7fa5aa8600422eeb345b85607
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 67572eef71edc0c4ef59b556b49aa45629bdf7fe2e9fd98544347ccf34c1b84e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_loong64.deb
     digest: a9a4357296b903262ec36179191f2245bd153128c1ab4ce0e6a27106170b5c2c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_loong64.deb
     digest: efca3b1e94b8678c86f2a5f96e63cc2e92966cd75e58e8a152586741e432250e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 642d79f05b64f5e87c68b2b2dc608aae245dbcc9633722e22c76690ed5d3cf28
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 4c634c8654c06847e5134e5c4e9e3cfe0c18f512a70f050720d0387658bc1dcf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 2468a7671a666d247c83784a2a0bc4a5d5a30adb3e3269c88dc271d57fb6ea31
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin2_loong64.deb
-    digest: 0595128d6048f657fd8f4ce06897ac52b32d6d3f9684c25586d7565297ec72c0
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin3_loong64.deb
+    digest: e758b59a95f52cbd81bcd68bc6bf76ea5fe30e55e2ff9e64db7fce5507b2ea34
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin2_loong64.deb
-    digest: e9211e4a6e575e2b384d5f71c4b9d06d75383766ba75963c937dd168cf5d83a4
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin3_loong64.deb
+    digest: cfe2420489d6d39b12ff2b71b50ae3240aa08f0b7c6695ae913ec75072ea4217
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 1f3a87afd485f8704fbe75357d769748b4733d0ddfb934c6e89e689e7344b4a1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_loong64.deb
     digest: a792f970a150d5fd7b60c3e265f8117600556b81eaa4a8834a1f65163a659e5d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
     digest: bcc5d3441b82068d621fe024b751eb6642182b5f86dc7b57de237edadf190818
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin8_loong64.deb
-    digest: 525b05b3ce75d544cf5ea74cd5a6e1c2b93a2f23ffd6c8873a40dd12f2c04e8d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin9_loong64.deb
+    digest: a2030468479218b5507a38ecb50ac94a988990891430fe8c34f5b4e590c57469
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin8_loong64.deb
-    digest: 31c2f8f33d70b9746d44027c51ff000da064f0055c4b3e125584e293e0bea125
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin9_loong64.deb
+    digest: 9e22d20ef0d22f5f8f498bb00fdc3d7290b1a89c5f798a25de09c1e11612101c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: ce4094716759c9c88fcb36b273986d8f0fa1328c3279757f3ab9737306b4027a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin8_loong64.deb
-    digest: aae584d1812fc7411e9f5d6bd45d97e7fc6e8a5f87b0f8aabeb5ace9c2be7d21
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin9_loong64.deb
+    digest: f8b55f6c519f163b6d1109597f7cb57b9fa990516f447e8df872ea45eeeee76b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 37a4d854d9d9c296b5092ebbea98b035a85fb5b871ca7ce2c365e98611899e2d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_loong64.deb
     digest: bfc60cbd6ee84fd4a6ee2d1002c27389d58dd451f8ec8bfde0e74fc8dbcfbbf4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/r/re2/libre2-10_20230301-3_loong64.deb
-    digest: 0b93a4f144a636109ba0ef47ce9be7f14ac78e87ca8f8794f75596c8ad624b03
-  - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libr/librist/librist4_0.2.7+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libr/librist/librist4_0.2.7+dfsg-1_loong64.deb
     digest: 14d4514b719515758c011e60486cdd4b3e652f1d556375f5e21a3e9029766874
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_loong64.deb
     digest: 3560dfdbcf90fef6f1fe16715e1bc7543a4e84b8759c58f71db0d93054bb7d49
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libs/libsepol/libsepol-dev_3.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libs/libsepol/libsepol-dev_3.5-2_loong64.deb
     digest: cd6de58ec8972c1be0f4028a31b7b94d8079bd1c0bb6af78c21ab1c1a0b245a2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_loong64.deb
     digest: 9667bac75f00cdf47520a2ec5d444bcafb4c8eb3e13efdf86218f5c69d68652b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libs/libsodium/libsodium23_1.0.18-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libs/libsodium/libsodium23_1.0.18-1_loong64.deb
     digest: 967fe90420e1c2608209f23f3a959adc2a3395203139559ef52a957bde15123a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
     digest: 760ec85164e31b757b0e46274b5a1eafe5a6ce53ccd0e1c4c1d7e5338e93c31e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_loong64.deb
     digest: e8619448ff773a2ab7ad66dfb6b345f899c47601e40b3982bd5b97dc701de1c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_loong64.deb
     digest: dea4a89cee5d7d70b6143ef55501595bfa963aee8777e0f1b10f46a78dc9e578
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libs/libssh/libssh-4_0.11.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libs/libssh/libssh-4_0.11.3-1_loong64.deb
     digest: 519a314568242027475eb9425196be7a19fad611cdccab8273cd7ac9f053de85
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
     digest: d5528cf8ef1dcf19b1b3245d894851bbddc35132ef3fd22e8c399fd5af91a514
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin6_loong64.deb
     digest: 173da37d81458fe8dfadee6ebaed4ee80611612684081f02931f9ae99fdbd1e6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
     digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/t/tiff/libtiff-dev_4.7.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/t/tiff/libtiff-dev_4.7.1-1_loong64.deb
     digest: 77b4f321cf7d20d5e1eea08eb961d3a706b8eaf103f831adcc392d32fc6e01c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/t/tiff/libtiffxx6_4.7.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/t/tiff/libtiffxx6_4.7.1-1_loong64.deb
     digest: 2de713a8a53213bbd72760b46ed8faf011bf4b22de1764e9fd0d7fdfb77515fb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libt/libtomcrypt/libtomcrypt1_1.18.2-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libt/libtomcrypt/libtomcrypt1_1.18.2-5_loong64.deb
     digest: 85e1e7482f2e1c928984391c424de9d81262ef9ad9535a1a5675eceb4dbe1830
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_loong64.deb
     digest: db75255d3c07f0d76e854af80a1a6090e023a5bba421ba75781bb669cf85a3ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
     digest: b2217959e0d34e5ce86a75b82acb235e1b887696044937815544c576c7abc9a7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/s/systemd/libudev-dev_255.2-4deepin19_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/systemd/libudev-dev_255.2-4deepin19_loong64.deb
     digest: a442e607fbba778852d8a8ba705ff39405dcce50f4a74754212275fa2f397ccc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libu/libudfread/libudfread0_1.1.2-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libu/libudfread/libudfread0_1.1.2-1_loong64.deb
     digest: 52fe8c374d5b0f18d538139bb314839f707a1ee6da3090d411fb9c2aa9c93e49
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_loong64.deb
     digest: ee8791150f1bfe803c6dc3cbbb699a5f6db83f9acea98d0d7af33db8cc50d929
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_loong64.deb
     digest: f85518b7ab894cce4194fa481c391a70ef19c368aa8bf8b755b2927ca1636a60
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwacom/libwacom-dev_1.12-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwacom/libwacom-dev_1.12-1_loong64.deb
     digest: 80b9f218239d0521b8c10264860dbf34673b210b56e82ee01ce149a997c57a0a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwacom/libwacom2_1.12-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwacom/libwacom2_1.12-1_loong64.deb
     digest: 87c13b7db15b7c19111c5af081825d48550cd48c351e3c5ddfac976939bd67b1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/w/wayland/libwayland-bin_1.23.1-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/w/wayland/libwayland-bin_1.23.1-3_loong64.deb
     digest: 82dc01f90ca12bba758c00e7591bb7423859729e15c55b9b7de7a066d82a0a53
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/w/wayland/libwayland-dev_1.23.1-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/w/wayland/libwayland-dev_1.23.1-3_loong64.deb
     digest: 74aa1a5380f582d3fa512b1e129fd02fc7adc739766f19561c369652e7024458
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwebm/libwebm1_1.0.0.31-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwebm/libwebm1_1.0.0.31-1_loong64.deb
     digest: e94dcc495430d1a7cbe0c2130043ef0db8037519e7d82550d5b62e9fbfe9959c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_loong64.deb
     digest: d1393a8e0ee0c5e7110a47cd729f042ac19b418bc2560f4fcb330ff1addddada
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_loong64.deb
     digest: 6d33f9002478ee47a87b1906776df767e1248a29ff07c07e03aa44980d5326ef
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libx11/libx11-dev_1.8.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libx11/libx11-dev_1.8.7-1_loong64.deb
     digest: 9ff2157ecf2cb67c552cb49d624b32ab2393991a184e5151b233288c9a71113d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libxau/libxau-dev_1.0.9-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libxau/libxau-dev_1.0.9-1_loong64.deb
     digest: 15f907de0f88e9aac91b9fca3c609de2330cfe0c847b91d73ed5f3e2c4d098f7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libxcb/libxcb1-dev_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libxcb/libxcb1-dev_1.15-1_loong64.deb
     digest: 3d4b82cd16df0487be74f8f9f79d27fd7b0c5252c2a1c7bd2e03fa6453059728
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_loong64.deb
     digest: fa296588f4f92220332e72311db7631b9e5734469551e34dfbef79b5bbd2b328
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_loong64.deb
     digest: ba47dce288d90726795169d45ddf9b07f57c9391776ab2a4833ac26fe01a9c90
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/liby/libyuv/libyuv0_0.0.1888.20240710-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/liby/libyuv/libyuv0_0.0.1888.20240710-3_loong64.deb
     digest: 5db04094a96e73a685b42d380eea7a3f3b84feeb02d941531246ecf45345d6fe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/z/zeromq3/libzmq5_4.3.5-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/z/zeromq3/libzmq5_4.3.5-1_loong64.deb
     digest: ea9300e3470746654e2977f1f42d4577d502625781cdf053bea7aeff012ea17b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_loong64.deb
     digest: 542cb13caf60619314815e4a117fb1e39c3540a241aa52a34fb9cc7b4717f08e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
     digest: 300cb587a7919079edbafd58ca6c5d82ec6783aff34e3f6ccb8c5f4f170c8a5d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/lsb/lsb-base_11.6_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/lsb/lsb-base_11.6_all.deb
     digest: f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_loong64.deb
     digest: a6b376c2fd149cc6cabd93cd94dea5c9793fe8e9b9773c22bb9a12812ac52cf4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/make-dfsg/make_4.4.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/make-dfsg/make_4.4.1-1_loong64.deb
     digest: 549a2844f1ba5051fd3be57714c0e2498054ebf269ecfe235e532a0b363e4f8d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
     digest: 848333f2b40b586ecf8f0db2b6127398d0423867e689937c4427ab15570e5581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
     digest: 729d9b051d2dcda0d0bf51fee21d3b685093314a0b2283926f1eb11f937cb04c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/patch/patch_2.8-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/patch/patch_2.8-2_loong64.deb
     digest: 96dd75e1b9172451e8876729a534d1f7a4a3b36476c849aec10309973c6bf44d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pkgconf/pkg-config_1.8.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pkgconf/pkg-config_1.8.1-4_loong64.deb
     digest: fb2ca56eebecd5c9dd6f9150062f349edcd4863390463d536927b6232658f8f0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_loong64.deb
     digest: 872f0376191a3cc26d0fcf9f60b5a2e81d68576cf18aa24449574147e7ce697f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/pkgconf/pkgconf_1.8.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/pkgconf/pkgconf_1.8.1-4_loong64.deb
     digest: 3e3b1b4df76ba6899f213996a11d75d1b01acc5ef6a9445ca9bb637cb8cd126b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
     digest: 4b0fffc886401daa9acfb53e2b190528e3fad37a49b989c4fae6715004fda41e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
     digest: 0287e6d08e13e90c9fb8672adc90fd30703e8f4911da23cf0025e7e1d6101533
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_loong64.deb
     digest: ce4d39684a0fc7bbc5c7eb4cf14b8f99562a8b08c92c98e7e0f240d862256f4a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: fb6e0f4ac13b05e7a6d6a72e1c1f8688f815e7a27befa9dd3d81b9aad2064d6e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 7a2a45e83693b157a7aeaba87b2be3b540b8c177d1b440c8d80fff0e73df2ee9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: e1ad2d94a1717f095ffa460962ecda44c7b75423415f9217357ecc7c4eba1082
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 493ec73280c028e4650dca12ff1f02447ac07d91d36ba5428e2e536e23a1c1c2
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: d27ddff8f49e1c939be776d3575027c051df84e38c38f470379f589bc202d4b6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 283deda7646d155272a2215e423bf27677da427e3b7e6cf7b617972939340448
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 27e12048ab69b6d9506f22438552de426eddc3f64e9e4bcb6c25f4c2b4b43954
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 7e658081496ab14aac8be1691f775d7aa63310c59d1560e86678f4b60898d8ee
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 69e0bdf6d9588fc8c65da95535dde9b524ad532564868227200459e54c6e4f99
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: f698f2c868dcc714e9c88f8480211dac0b664e0b8e8ec90b8685bf43a7090eed
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 6fa09645e98fe4e339d7dcab8897480a91ff19f92639d9bebb28e421a9e28c05
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 1b0764b5119ca5b9558e6b45b464dd7cfa894710b3f940718b8aad070023c722
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: c660bc164102bf4d36d61eb7f4537c53cc8f8e2255556c3f8e3e6c1e52950dca
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: e3e244ab71297be8400e9ee1143cd472bdaafa8a928ee5206d009569b853a57c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 3db7feb7701baa968031f1ee7d7753e0e555c0ce6e7273faf51172976c16f3f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 6be15564b7ef791d91a9532bb2c280eaa21d084fec545bc298922a7b16d21c0a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 1b092bcb57751ff8bcc71c7af75bcc0f75bf4e41d8e532c11453362dda415108
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 5f6fea654b1801f3c887bf8fa2e05fbbeb88501070bd7f158f5dcb020f191bab
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 45dcf0638ea0ea67ac02d068bb54b908659cb71b220dac0f7169e1c5facc21bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_loong64.deb
     digest: ccfaec5003e238ac01b62089ee0f4c52ba30e9ef5370c3afa17e3cf7ee6bb318
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 5bcd3e8cd74565929fc33f73bf524fa7e08d71022918781a70a3dda23683fcef
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: a886e5d99052250ac88865877c9d2ae9bb2863f8fd90993738e264ada279a9c6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_loong64.deb
     digest: 43df515525771e1c6d23246fa728102c60a6fa6ceb37769bf3903b190b50f819
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_loong64.deb
     digest: f9530e42280535cf1f08732b4a307c112baa3820b4bd185bce1577d20eaf6aa1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: c81d7f3b2df67350db93541d23c0a7d7921c17830fec332354bcb8dc7f12c735
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: d57c2b241915798dd215f857ef5e478d9e544321372d848459f32b87b8ef9f4e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 4460e63936050e5f21dcc9f128b5fe05556ee389a06bf6dcd6c0451df89aaec7
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 34f9d27dbb8607499dd9d51941eb2399dbd242ad417b94bf09d8b090815b6026
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 276998df4b2e653e8f9f8d26958f8931098f31ed5e33b69caf2286ecc20eab2f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 944469b76b2fbeced41a2a62c7be09783c0494269aa8c48cf6a97cd813be71fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 09a3acdf952f421497debe4c6b5360f54bdb74a65f68d694390bd13b3a7c93ef
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 47981a121f3e63f6451f12b05a83f2965a0ef189642f494f2b91055a31302701
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.37_loong64.deb
-    digest: 9bab0989624a67904b7bb847fe1b0447a969b3fd3c7a4159b4bd1845b18d0702
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.41_loong64.deb
+    digest: 7a89bbef7d962367e92cbcb43411f37c2b410127191afdfa13f7015ebb974428
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 49ae2c7586e26fd8468f4d988b0da5891cab0d7ac2ef9b75633d0ac6cfba8da2
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 89220285e6ced9c9143db6a21753caab7c7ed7fe8bb1a4a9e2738366b6951f24
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 3c46ce25bf0e510c1c38da64bbc4560429d6d4451f8e2901237e5989589573e6
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 838ba98020e3d69283491480a0cf6914de962ad9ca563fa256e9b7641928bf12
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: bd389c97bdd2b52b86545a911331cac4bdf25af39b0bdee5f1989bf07860110f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 333e720a1a0b1543b1766fc5653dbb48e6b9937f2930a57a30175e1531122a91
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 585e897d3dd100de0c98ec33a5ebc21d47b48aa85951020a3f9f128523a73988
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 86d9a37e183a7519d39d0cf83a1a606285cda1c0f280ed503a58b6e5826d9e43
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: bb22a0278adde746a4d632682ee20ff8aff9e71d1ae114ed1a8af0dcd35db0e4
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 8a754ad07d6b66724570dc90a2353421545c43f867403737e88ca84c0b0189ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: b9d3ae1f5681bb8da1fac94a5f989675efe024f397093be0777bedb751c76ebd
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: b17f1dc8a2dab45c21f87fe35c51d8c02c340458587c39d9da78e677b9123224
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 4f4701fd3698b45101a477442866fc6095e1a2b8c2bacd1ea69db55065ce1153
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 5041f81baeabab7b0bab0cc090ab4f3552917f7acc6be2d30d0f1d9419097442
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: cf79e8a38be1c990342e01ed1ebfe61319a538e105a7eecf9afe91fcb570c19e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: c1dd0ef8b4746603fbf714fafd662a459778fb20b3c40203b90b65746e804ba9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: d4b0bad9b906012d8694caf56e7494e249803405d144fdc4a41b185a30aefc90
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 51fc64212ad9899a97363231cba60ebba70f7845e2507c330d0073a94f006593
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: e37e6797377a504c349e2f0f0f4fb220dd8a7c461a3f66348827786147ba6694
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 9ddddaeab936da42efff955dd2cab814264d69e10b2f296ff9e46611eaf0d0f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: fd66ce184fa441a4eb27d5e08fe3c6df58e39addc23f80642fea1e5bbd43e052
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 67567d99b1cb360c5262235f3beb2a25cee2206956cda216b34c81b92cb07323
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_loong64.deb
     digest: ed0e44c516e67bda0898057181b8a1c8c75dd729fdad49961e47b0d44bc9a5f6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 26132e19fb84487760cdf91671c346578067bec3b9bd4830462a117852309eb3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 6bbaf526f9e5d1d89e995907343a88f986cec61d670b5ee49612a83357ebd9ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 98ca3c84903afde79a6625e941f0755dd3901390c5309c8642d5b9d5bb5d8ea8
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 224a5466424babd2e9e0318b4c6a4beeb359e91bd5aae75532321b936323d012
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_loong64.deb
     digest: d3e7911d9c70e0095aff698f109dc879c5e41606bd7feb91d6eb0ae6d9e72753
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin8_loong64.deb
-    digest: 22cae869446d4d022e75aa15d6319f6a32bc7d8e9f99ad6e4296e9363e7303c3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin9_loong64.deb
+    digest: ee25e73ef10f4bb7ff55bf95f2d82b69c510842c3d27d2bef3f70b7a0f94f288
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin8_loong64.deb
-    digest: c5446cdfab177c2c22ac7ecbc3c93ddf386e3eea573b2ba0675ba08e51ad53f4
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin9_loong64.deb
+    digest: 656bdc515088888be04a6a9ddebb5cb00a85585976c371014ed8867f75da2882
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 9a9fe8fe81899d37cf34034332fb3930c6114e4cd71d31098ff51f0fe15d176b
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 8607c86382ad4683b1a74d75098b858892a530f3d72f374b183ce0975b1ef2a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_loong64.deb
     digest: 663ebb93a2d4c641de8c11920366c7b697027bfd35d3e41ca65b514016234b5f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_loong64.deb
     digest: a18046026562749119024973ad4a10eb2dac2cb6cd394c96054c2e29a380eb03
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 1e4782dc0f2d7e3e34a04af8fc4035f7674567717fef03211167842ad09d9bb4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 983001e7e63072707300368401c0abf15f2d6a1d557d803bdc7c6488012f5115
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 07580c3761ef13a0c8bbde093a3c596868cd3222a1466dc97da02c89b73eb98d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 7c9bc44803d5cf01f4635dacb762f24066e345cd42d74d44fd15e27bdfc6f07b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 0855d1164c83ec6422dd452e55e82c32da39517986333dd2868c2009a2073197
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 9b0e724d139a969e355ea1887cc94223fcb2d4dee57edc6594d4c9de07dc10ef
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 1a6bba7239c476f32e48502b9cb4da35cb18b1380f3cda7b9d717d7987320209
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: b3549283782bf11d23448ff8d6501f3d37db3140245ec45f44db690942cc439d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
     digest: ec3065e7d3127545cbb6dfe84c2d9f7e38b015a368033c1b8c67d955f8001b95
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 3ff56c6a9e982c44e70ae641d669cd64aa871e950cc2916812ab582f5518a8d3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_loong64.deb
     digest: 53a2079f81a2fdfbc7662bab8e901eadc88d129908f90e7ab759bcf6c4f74c29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
     digest: 91e20e6b2f68393e3b4764b9f57d55ac495174485239a607f994ef1aee08c459
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_loong64.deb
     digest: b1199d84256f297e6dd6d3b3cfe173285df461da56b10742c9dcae91c616675a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 62662b017f7c055b8a7b914bc0c97c976ff2f9e9458c732e3e96f948ca4d6d3d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 0b272edbb22391b818dd249140ebbe5442a4ef938eeeac146012140571d224cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin10_loong64.deb
-    digest: 33742b910a603260938df089dd6befaf86d475c8ffe40300ea46f894fa4a3b1a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin11_loong64.deb
+    digest: 8fc61822a0368657c7d0a794efc39166ce1c6f0df93a77a593ac9a7264cdeb5e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_loong64.deb
     digest: d34656ffcbbb09534dd7cb5c7d7a05a813b3e739f74c1a95958a2e3ac4307178
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_loong64.deb
     digest: 366fe25e1aa641f31c261a422cd578724b47e3336d43a913e24a3d0c3d18c1a2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_loong64.deb
     digest: f7d6d0e11fea53ada98657b4a547a7758ba1fa1e0aefe109b9b1605a51ce0bb1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_loong64.deb
     digest: 0b390252dfa1e2666f40d6ab8fb75535169d22b21879c19a67f9cda4efd1432c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin2_loong64.deb
-    digest: 5246d12d0c75caaee0840b2cb53c9a4003a70ccb2d622db3250015a1c40afcb9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin3_loong64.deb
+    digest: b683a30184a34222c3773386ab1ed03d8a6c4e4cd33f6fe5e13ed3a7a0bfb0b1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin2_loong64.deb
-    digest: e13994b16bdcb9bd0e4bd4fbd469767f03889e474771ce3ec8bfe0087a14cd65
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin3_loong64.deb
+    digest: 98266a670602e95416d378d0e5ce9e3a8f39227307b385436230aaaca9fceee8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_loong64.deb
     digest: 4c27718be3d7bb75aeb12a2b6ffa4764e4600edb6b06cf3f31f45f99c70b6fcb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_loong64.deb
     digest: b41b3f13bf4aecc868c876dab50bac5adb4471ccf989ae8641a2fdc7a83878b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_loong64.deb
     digest: 46026db29c9ff37a25638150ed457ef56d8a29b5c973ba386ae44ff0ec30ba03
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
     digest: dbfa88dae0e66fa60e6558fa80242bb78be8dec5b37ea449f85826b1b48cf25c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin8_loong64.deb
-    digest: bbf1d9dab81dddf438e619f2d08d2c1ab79bb3878965f437c81711ca0b919333
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin9_loong64.deb
+    digest: 5d6415fba35f03e399da885433abf6e919453641823532d667a0613ca9dc30ee
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin8_loong64.deb
-    digest: 2a0fc550216f91ad0fa8ba8d9f822ad9827ef6780f83ea21dbc3073d6dc21e53
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin9_loong64.deb
+    digest: c50326b312808f7d9ac333656223263e86f1c2669d9a7c75578c8fa548aa89fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin8_loong64.deb
-    digest: 0b67d06a8a0980b4fc7745178d0efae10ba26d01c565fa12ae15f213280e97ce
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin9_loong64.deb
+    digest: 3e2c026ab4afa50db7776c2e7d5302ecece1f5e11bc0fa274fe3de39fe6bd757
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin8_loong64.deb
-    digest: fb191dfa1dae0b5540f75a1935e4a8abd53093a53c532c66de9db3d1f23d9643
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin9_loong64.deb
+    digest: 0e5306c16e756240822a7160b639044cbac499bae184dac051c7e2368aa5b09d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
     digest: e70bbe5b35aa1009f8d3e8d58634052977864bad1d854230add6758ef238b1bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 28127b83086c739c5c99df069d31a9c6c5f37fae878abd1d928321a6c97cb986
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
+    digest: aae8ac2b6d3198d297d430cdb97e556365be2ff46d06525008ce071d97ac69c7
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/uos-license-content/uos-license-content_2.0.5_loong64.deb
+    digest: 913f09d45bea05a28e246eb884b1ccbe7572c540507fe16271acc6e1a9876a5d
+  - kind: file
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_loong64.deb
     digest: 8097f0f8c46e7619c944b22fb4160d60ac3b3eb5aab3d5ea26a7c83816ed24bd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
     digest: 82bff9dab1d74e30bdbc6130f94d1bd361c3c1d3cdad660bd92e5b730c4cba7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260415/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260519_1/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
     digest: b40d74ed9b2014e3a3bcb7c6121a17e16424d0ef19c9ee1aef977b7460b1b1b6

--- a/mips64/linglong.yaml
+++ b/mips64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 25.2.2.4
+  version: 25.2.2.5
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -176,6 +176,8 @@ sources:
   # linglong:gen_deb_source install libfcitx5-qt6-dev
   # source package deepin-shortcut-viewer
   # linglong:gen_deb_source install deepin-shortcut-viewer
+  # source package uos-license-content
+  # linglong:gen_deb_source install uos-license-content
   - kind: file
     url: https://pools.uniontech.com/desktop-professional-V25/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_mips64el.deb
     digest: 57fe3a41ae98855bea2f46a967dadb0b7411f2e456a5e19817bf6b446bc36b90
@@ -446,9 +448,6 @@ sources:
   - kind: file
     url: https://pools.uniontech.com/desktop-professional-V25/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin8_mips64el.deb
     digest: f598b6ebb2d8a78d60ded3b6086d1a10af18a39155a19a40844ff563122a23dc
-  - kind: file
-    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/m/mpg123/libmpg123-0_1.32.3-1_mips64el.deb
-    digest: d5693e2ec76996e0e057cbc437845890605189f5528b63c849b58969de952461
   - kind: file
     url: https://pools.uniontech.com/desktop-professional-V25/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_mips64el.deb
     digest: c7de03bb198bab3fb08f86947434b162952760e08086b688a989a03a18ba0897
@@ -980,6 +979,9 @@ sources:
   - kind: file
     url: https://pools.uniontech.com/desktop-professional-V25/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_mips64el.deb
     digest: 50fb06298f70a5c3045b95c5612e0229e28f180bca30bc577e6b1432878b0bfe
+  - kind: file
+    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/u/uos-license-content/uos-license-content_1.1.36.3-1_mips64el.deb
+    digest: e8b8e5c008dcb21057646a25f2459583f0bd1bc58a1c4f7b2caea5a038aa75c6
   - kind: file
     url: https://pools.uniontech.com/desktop-professional-V25/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: def7f740c6520d8c1b210b6c71fc648b4106abc22c16830a2dff68aebf24a058

--- a/sw64/linglong.yaml
+++ b/sw64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 25.2.2.4
+  version: 25.2.2.5
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -176,6 +176,8 @@ sources:
   # linglong:gen_deb_source install libfcitx5-qt6-dev
   # source package deepin-shortcut-viewer
   # linglong:gen_deb_source install deepin-shortcut-viewer
+  # source package uos-license-content
+  # linglong:gen_deb_source install uos-license-content
   - kind: file
     url: https://pools.uniontech.com/desktop-professional-V25/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_sw64.deb
     digest: 637b3d77dbb06fcaac2d23df85135d52cc8b4a4a1cab3b5aa3d213e27e40a4d1
@@ -437,9 +439,6 @@ sources:
   - kind: file
     url: https://pools.uniontech.com/desktop-professional-V25/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin8_sw64.deb
     digest: 53845c1dcd088b587df14a7c300f9e875fc586bd932d9fc9005a120bfdbe6571
-  - kind: file
-    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/m/mpg123/libmpg123-0_1.32.3-1_sw64.deb
-    digest: f28a534da871e5573ca0c0ada3172f590be9a026c7f36175544885c6fe251159
   - kind: file
     url: https://pools.uniontech.com/desktop-professional-V25/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_sw64.deb
     digest: 81291cdacea7e14c8f5fc6dd1c294f3e8b2079e621b4fd169f498fcbb02cfa56
@@ -974,6 +973,9 @@ sources:
   - kind: file
     url: https://pools.uniontech.com/desktop-professional-V25/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_sw64.deb
     digest: 78a4da0fe08f83d70b4d7f2850b87eb10e270f35ca58ec95a7bfc5170e091417
+  - kind: file
+    url: https://pools.uniontech.com/desktop-professional-V25/pool/main/u/uos-license-content/uos-license-content_1.1.36.3-1_sw64.deb
+    digest: fb8bd4ed0fe0b76c8ec5e1161d5836ef6bfdb3a5aefa82886223c0ca37745782
   - kind: file
     url: https://pools.uniontech.com/desktop-professional-V25/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: def7f740c6520d8c1b210b6c71fc648b4106abc22c16830a2dff68aebf24a058

--- a/update.go
+++ b/update.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	deepinRepoURL = "http://10.20.64.92:8080/crimson_runtime/stable_20260415"
+	deepinRepoURL = "http://10.20.64.92:8080/crimson_runtime/stable_20260519_1"
 	uosRepoURL    = "https://pools.uniontech.com/desktop-professional-V25"
 
 	deepinCodename = "stable"
@@ -44,6 +44,7 @@ var (
 
 		"fcitx5-qt",
 		"deepin-shortcut-viewer",
+		"uos-license-content",
 	}
 )
 


### PR DESCRIPTION
1. Update package version from 25.2.2.4 to 25.2.2.5 across all architectures
2. Upgrade repository URL from stable_20260415 to stable_20260519_1 for amd64, arm64, and loong64
3. Add uos-license-content package to all architecture configurations
4. Update DTK packages from version 6.7.34/6.7.37/6.7.38 to 6.7.41
5. Update Qt6 declarative packages from 0deepin10 to 0deepin11
6. Update Qt6 wayland packages from 0deepin8 to 0deepin9
7. Update Qt6 SVG packages from 0deepin2 to 0deepin3
8. Remove libmpg123-0 package from loong64, mips64, and sw64 configurations
9. Add spdx-licenses package to amd64, arm64, and loong64 configurations
10. Update update.go script with new repository URL and uos-license- content package

Influence:
1. Verify runtime builds successfully on all architectures (amd64, arm64, loong64, mips64, sw64)
2. Test DTK application compatibility with updated DTK 6.7.41 packages
3. Verify Qt6 declarative module functionality after version bump to 0deepin11
4. Test Qt6 wayland integration with updated 0deepin9 packages
5. Confirm uos-license-content package is properly installed and accessible
6. Verify spdx-licenses package installation on supported architectures
7. Test application startup and basic functionality after runtime update
8. Validate package download URLs and checksums match expected values