### PR TITLE
feat: update DTK runtime to version 25.2.2.9

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 25.2.2.8
+  version: 25.2.2.9
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -13,7 +13,7 @@ build: |
   bash -e build.bash
 
 sources:
-  # linglong:gen_deb_source sources arm64 http://10.20.64.92:8080/crimson_runtime/stable_20260617 stable main
+  # linglong:gen_deb_source sources arm64 http://10.20.64.92:8080/crimson_runtime/stable_20260623 stable main
   # source package qt6-base
   # linglong:gen_deb_source install libqt6concurrent6
   # linglong:gen_deb_source install libqt6core6
@@ -179,818 +179,818 @@ sources:
   # source package uos-license-content
   # linglong:gen_deb_source install uos-license-content
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_arm64.deb
     digest: 8640b3a520c753202b7522eb12370205694c88cd354b3b24d4bb5fd25d51fba2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.41-6deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.41-6deepin11_arm64.deb
     digest: 49430242acd8bdb7fd942ccefc4ef5f9327e73534dbad5e15641670f1eb123bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dbus-broker/dbus-broker_29-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dbus-broker/dbus-broker_29-3_arm64.deb
     digest: 85ea96ecd1c36047a88b101d796617cab7fa4158f08180e7d275c799fb1ad97a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt5integration/dde-qt6integration_6.7.43_arm64.deb
-    digest: 3e2c790e205b3221c49edfb795204e23d9e8a247f6072e5488977c8186557533
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt5integration/dde-qt6integration_6.7.44_arm64.deb
+    digest: ff7de222e4eb59cced2c0ee23a64a2332080dced149e271d6d25e8b3dc1b51ee
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.43_arm64.deb
-    digest: 27d147348a25a25b8f578978650560e9e63cd9c3b5501ff626bb263acbb2285f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.44_arm64.deb
+    digest: e89f739720d72dcff81ba20765349a5cd4d22da16ab6b27c837465e25deca08c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_arm64.deb
     digest: 14c2e40bd300f261f972a8f029e7276efbb5d800c5c0ff32cfceb3584f8529a2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
     digest: 56be397887b8d4a953202fbfc4342e7a675ef386497abaf0d7f95521340c28a2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
     digest: ad27e359a1fe3485255ce3c17eab99ae42ce1aa03acd67e45a2751710dc463c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.43_arm64.deb
-    digest: a4209fdd825204e8470b2dc93d4fd3ac245e12884c370a5753f5795a27da91f2
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.44_arm64.deb
+    digest: f515591e99292f3ce0cf6592d897eb14c3aad101ac802f90487e0276c028c3b8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.8-2deepin3+rb1_arm64.deb
-    digest: bf16b02ed463d630ae4c9df0fa6b99b37b01de9d5d70ed66b019c3a814c71e43
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.9-1_arm64.deb
+    digest: c70fabca6786d7044493121c291665b035c8869310671563088d1d799336e2bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
     digest: fafd08c872d1279aa0bde2e0bdf40a57721961934c0593352b6a2c551aa232a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
     digest: ef932bad267f9d4d49c0c376ae1d0fc1a9b595054f8450d42b2a0d6621bc7084
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_arm64.deb
     digest: f860cae29e09459e0d4e8eba441c6f3cd653f0d324524d4a92b59e6aa0c70dd3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin9_arm64.deb
     digest: 48de304ec3a97a94911a533935f6b4fe5e0dad63e1c0971633f8c26772a7a660
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
     digest: cac541f3cf746d006b71a08f88364b6743222b8956fda9a7cbd35ffb1cf32ed9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_arm64.deb
     digest: d95934f82db8aedd2ee282cd44e0088363b484f99fc679ab2992d0109a079518
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_arm64.deb
     digest: 321b50e4ee0efc4aaa9e67168e4b88216733e1c012d269e6e9f2c04941a66ec0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/b/brotli/libbrotli-dev_1.1.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/b/brotli/libbrotli-dev_1.1.0-2_arm64.deb
     digest: 016574d411e89311351ae6117b766a6bfa1ef7c0f49a4e17601200a33c2a19b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_arm64.deb
     digest: 502bf30d0f5d2a06d33495526cb4f5f7929623e87ed3c716aafb91f29565c1c3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/capstone/libcapstone5_5.0.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/capstone/libcapstone5_5.0.3-1_arm64.deb
     digest: 69c419efd4b58c93eadb583e4d1465b9d91355a3eb599c3d6ac0dcfacb685d8d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_arm64.deb
     digest: 39486fac0b8bd52f8641e2586befaa00aeb6a03106f3b6c99e64039c8e7b4a6e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_arm64.deb
     digest: 0a6ac3348d454cf7a354cfaaf03d67a74c12168356fd5cd896919083f1d3944f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_arm64.deb
     digest: d6afcd6261c54705b8c631dc598bde29ac135bfdce8befba68ee4abebaff8189
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_arm64.deb
     digest: e7ed6d3eb913cdca3b70df28573917194d19c5dff9e1f7b3989bbebb9f02e6c4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_arm64.deb
     digest: 7b3556881a1197e81b499d39c6cf38ac7c7108df05684c880fcce3e434f9ff6d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_arm64.deb
     digest: d9d85c3bd18fc8a2bb701abc9550f9181797a25ebd1f2a0c4e41c2cc4186d7d6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_arm64.deb
     digest: 3c9ab42334735ffef9fefe39236a25a5c081440ba0f0b0ae4c536a4baba81eb3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
     digest: 78e9245e377c8f61009cc60d2b55001aaddd7b656fceb916b3ba8f07344251b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
     digest: 5ac1e65112a190dfca99abf002e3e3f0ee033919b7b65cef5e3637ff1821cc9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcore/libdtk6core-bin_6.7.43_arm64.deb
-    digest: 46544cd1857ff9bba021a60db767cb18ac1505a82aefae50a7cdd0bca93f0077
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcore/libdtk6core-bin_6.7.44_arm64.deb
+    digest: e1519bff5d68bc9a25b12130e8413d08340bc5b6e6d9533f38f2fbe0f445abbd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcore/libdtk6core-dev_6.7.43_arm64.deb
-    digest: 0d66ceadf21b37982fb8f5692428c32adebac1312afa33084d55b45937e84a7a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcore/libdtk6core-dev_6.7.44_arm64.deb
+    digest: 5adf87553cbe4f443516718412d7e19a54bdbdf409ecfc9b4539d505a7dfdd40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcore/libdtk6core_6.7.43_arm64.deb
-    digest: a621616bdbb552b0fb3f471859498a1eaf46a01fd396b3b76fefdabe1b041614
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcore/libdtk6core_6.7.44_arm64.deb
+    digest: f00ae9ccb2640991802fb9a17ddde2dcf166a1d9a3406ec96299fab4b1500045
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.43_arm64.deb
-    digest: e54eb8c1b4421f5e5ca5e9ffd75c4410a8477f14daa041eef94cd6b5471816c9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.44_arm64.deb
+    digest: 1219d196262e9de98fb9976052e0918ee6e52850e33064b022eef8f338d52b78
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.43_arm64.deb
-    digest: 1977d9cd9529a9eb006e7682a03d1ad82050284df56afb447087d55fed114fdc
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.44_arm64.deb
+    digest: 8cb739ae9c02952fefa71fa7372f0d4e734557f9e9d07836d790beef27a66da3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkgui/libdtk6gui-bin_6.7.43_arm64.deb
-    digest: fe0631794523fbcb6032a09d40b4d2875b582fe7d04d72621bd94c211527f2fa
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkgui/libdtk6gui-bin_6.7.44_arm64.deb
+    digest: 82d5ccf9e27fca71653b563e37d5ea6c846f03e634526b0405a527a71e663d73
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkgui/libdtk6gui-dev_6.7.43_arm64.deb
-    digest: 81d1be4f220813695b21bd73b8c3c222f95e2b72975d6de116087225d6052f09
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkgui/libdtk6gui-dev_6.7.44_arm64.deb
+    digest: 3985373e2c9704d57a1f6f3f96951c3d04d9f9b4897c4ee54b6269f9e688df9f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkgui/libdtk6gui_6.7.43_arm64.deb
-    digest: ec747513cc962135dfe4b4cbdb2f3442e2c29a5908f0e419cfe6d2c93d5e58f0
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkgui/libdtk6gui_6.7.44_arm64.deb
+    digest: 50057d0092188b2539b88c9031a0b2a6e452b6a1d26091f0c1e0b4a43e6afe43
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtklog/libdtk6log-dev_6.7.43_arm64.deb
-    digest: f7e97c6eb4e19d95abed67b6847d164d3783283f7a81f68ab873aeee8876999a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtklog/libdtk6log-dev_6.7.44_arm64.deb
+    digest: 51b1fa0eae00e5e07717dfae22f334256949fc2c69804e8cd0af6fe9f4d9781e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtklog/libdtk6log_6.7.43_arm64.deb
-    digest: 7a37304a9a26b50b9746fd893220267a13dcfb78bdb353a4919faeafd772fe1e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtklog/libdtk6log_6.7.44_arm64.deb
+    digest: f397a2518aad02c03a72f53f90278940a904181cb29cf550f79b54c0cd08e92e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.43_arm64.deb
-    digest: 38ddf4d2a3be5f7317a89aa8e5c1b7ced607878a89355b40a3263d192ac04523
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.44_arm64.deb
+    digest: 41231ab30255c22601e8c2bd95053330fa42cc0bed78c6950eb45278b799fa61
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.43_arm64.deb
-    digest: 4560f873b9d9ff15ca42a6a8137763660eef7deaf87cb104a90784d75780a6d6
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.44_arm64.deb
+    digest: 9a35558f5ec21b648cc5b651c9ac6b83847023520c3084a76a9b975af9173ec4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkwidget/libdtk6widget_6.7.43_arm64.deb
-    digest: 448f3571ae730a18a2905775b05fd510dcf90cbd5ea82bab80d64876b5593be4
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkwidget/libdtk6widget_6.7.44_arm64.deb
+    digest: 9dcd23757b5837dc07e2b1f5f41dd36b7d8da9c1d27b956bcdbace3a58dc9cb6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.43_arm64.deb
-    digest: d5108104ab9a358591c65919d055496a206258798144cf4bcd4bc98543c36c19
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.44_arm64.deb
+    digest: 0b59c4d0f6a9b3c249454854aded3cc64d9436c39830b0487d6c801e0ac6bf61
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcommon/libdtkdata_6.7.43_arm64.deb
-    digest: 6fd99a413f2ef9a3eba4dfa3af32ce55e806a311f2c8a81daecf3465a9833fd1
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcommon/libdtkdata_6.7.44_arm64.deb
+    digest: 719bf3862f92937bc0d56d1fadabe1b8e612d2b7c82c4d3ab275b573efcee6f6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_arm64.deb
     digest: 14c66f6e25da4f8f2bf1b53b74126adbed322071850c68cdbf47795ac59df996
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_arm64.deb
     digest: 8698ae77f431746eca65194045fd226926b6cfe2797e4b6b81cd720e9717fc38
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/e/expat/libexpat1-dev_2.7.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/e/expat/libexpat1-dev_2.7.4-1_arm64.deb
     digest: ad7f54cb17830a0ddbad2492953411e37cc1d5d1036c567e5b057b70f30d5a12
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_arm64.deb
     digest: 9031aba011c7fbda1347bcbaf9351128ea600807b5f303835af17729e81ab28f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.8-2deepin3+rb1_all.deb
-    digest: c5323498567c4b1fd58c620d024a153dc9ed17de13291d25e41f89a214007b62
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.9-1_all.deb
+    digest: 095f6c357e994b15d51e9cf85722cbdf80f821a8ba2e5b2310fb9a40bb2529b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.8-2deepin3+rb1_arm64.deb
-    digest: 031aaab648d0fb1c457d499fd8a10ff29f2f9bb03dcf38db0c62346fbdbc852e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.9-1_arm64.deb
+    digest: de6d77367b2ed4e1fa4027e43cd25e67064b6f8b45d47566e584b2036bd85005
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.8-2deepin3+rb1_arm64.deb
-    digest: 82ec9bde20668ae033d6be79f693cfb2213732c05c081ba7f9c8280eccd19202
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.9-1_arm64.deb
+    digest: 8ed2a04860f0fa8d681eb7f6aa59c9f8a8ff9f41a7eaa21d7bd2b6ebcbf3cad4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin1_arm64.deb
     digest: 3cd614e9c7ce6b165ea4325ac2b49b5df33df69d25f0f62673f5d2100ee398b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
     digest: 44b6f1a9aceead0cac121cfd13cdd9a529eb2b60522f8482c7dc4f67432d1904
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/flite/libflite1_2.2-7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/flite/libflite1_2.2-7_arm64.deb
     digest: c78ff59f928670a34074654ae5506c4f021af1ba56d9ebb4ba82aa7e49a0834a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_arm64.deb
     digest: 510d2d650a4a84adfd68c2ca880c8b7902ebe8fa14646f8544252189caa22eb3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_arm64.deb
     digest: 4e86b2e07435f652e068a77a7ee30444b38e52cf84a5d5bd2564c86d76af9e3b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_arm64.deb
     digest: 940d76752d4d561b14a8b3109a417d83bb24d5aeb6e7d9fdec5190ba0bd12af6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_arm64.deb
     digest: 623fa8b60136b4dc9182483dd53b310e60823ec8e0b58a6156d079acce2759e5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_arm64.deb
     digest: ef605bf23fa580844d6a5faa61caf503f3825bc69acc9e30dab40689116a2627
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_arm64.deb
     digest: 7819d43f2aee082ab6bbddc14a8a0446e606299e9436352accd31ce2af0ab205
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_arm64.deb
     digest: e4b703bd44e05dbb28208e7b07325f91db880690786cecd3f06632e39e4e588b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_arm64.deb
     digest: ff60370ae98f4515ea9eda99af3ab9d468b53b23bdd22f4b51abf8064655e810
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_arm64.deb
     digest: 6be533a6b6cb8b661664fedbe661b316edd0bee46f51fe598d300c2efaf95728
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_arm64.deb
     digest: 49a17d5a14ebd80404cbdb696735b1cb8fe14045bc5bbb5bdec0372528bd18a7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libgudev/libgudev-1.0-0_238-6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libgudev/libgudev-1.0-0_238-6_arm64.deb
     digest: feddaaa5fe03ccd3d27cecc446c9392f18e5022321a3796597249b662650cb25
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_arm64.deb
     digest: 4ee7382858ba8b140e0110cc59475db2dea7ad0b56a21e825528e5a2d0d1f7a0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_arm64.deb
     digest: 1af178c5a43fc3f1a40d90a4890bf8a00372449495bc32e6ddd82165927b3591
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_arm64.deb
     digest: 787936458a32bbd6da2c8eb749f831032036ff8a2e1c96644d56760777e9a3ee
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_arm64.deb
     digest: fc130cb8c18c9b08c7eeb72a9a7d340d844228417e36acac217ee8fe93e60150
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_arm64.deb
     digest: d42f1915689855e67552d66c8ac63370fb5b93e898461560fffcedbeac8c0ec7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_arm64.deb
     digest: d554b612e70c2416c6d831b575c1bc1c3f4c0143454ada80203e08f918143e77
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_arm64.deb
     digest: 7eb0cf9914476bdf669f0087c7fcba1d0cfd49f9697804d72fd2869e6fc3ecf6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_arm64.deb
     digest: 4355b250325f762945b8d68dbb1e39fd0847230f9bf56284c35d4a69aa819e5a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_arm64.deb
     digest: 1084fe140088878214dd72f6c8ebf4f4835b83f542ed443ce79cc2f43821d6d9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_arm64.deb
     digest: 82d472f20711c3b0eee4afb2b8bc8a0971f6fb7ced7612317f07597768e6ddad
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_arm64.deb
     digest: 0e91a2383f5ab980fb06cb347c66dc6b6480a7b76cb67ded44bb4b183f295d21
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_arm64.deb
     digest: 9516df25229fcf17ab431b82f89da91c6defb1aad63df171ac3370ba0fff48cf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_arm64.deb
     digest: 485cbd67d6d1e4939265893887a62e97d80190d524f5373f78d5ddaa2f22dcb5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/md4c/libmd4c0_0.4.8-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/md4c/libmd4c0_0.4.8-1_arm64.deb
     digest: 8b58cf124cb0a435765f6cbc7bc8a59d431a8f84babbc2956beb1a46b53b99f5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_arm64.deb
     digest: 15763cf880b4073ba036e05f2a3b9b46aa43802f9d2c49848fd315a9229d9be8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_arm64.deb
     digest: d3b3c567419dffdf8395282df0f2a766320a8071bae29509155e68e526cc7d87
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_arm64.deb
     digest: 17fc6b739d5d25e6139f8786daa9ac90b81315dfde9df401d7a8896831bc1828
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mtdev/libmtdev1_1.1.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mtdev/libmtdev1_1.1.6-1_arm64.deb
     digest: 646172dd88b260728ef1da45a78d41c78161a8341d0ce43de738c63f2e4089ca
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_arm64.deb
     digest: 06f3609b64811a80941b259736bb1f71a58633df1300b979a4458fd92a3d634e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
     digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_arm64.deb
     digest: 218417ca4ee32acb47bd698999e03414161810f034ee895f54a75ed79b15345a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_arm64.deb
     digest: d52a6102a07d9cff9066f0e3ebd802ab14e119bd1f9a890999be8cfda4c2cdce
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_arm64.deb
     digest: 04f4ffdf19ebd3ccfbcbc32489b3fc651ef75dd1b33cae10e5ecb3c8c4287332
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pcre2/libpcre2-32-0_10.46-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pcre2/libpcre2-32-0_10.46-1_arm64.deb
     digest: ce2687d8eb755b1a3a7cebfc0fbbd94c2ceb01e7fa4dd7f84615c424a91b3427
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pcre2/libpcre2-dev_10.46-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pcre2/libpcre2-dev_10.46-1_arm64.deb
     digest: c36a3f37e6ac821c11b69b2cc0fbd23ee36a526f69bf249f2f32c566b24928b8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pcre2/libpcre2-posix3_10.46-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pcre2/libpcre2-posix3_10.46-1_arm64.deb
     digest: 83bbfc7bb285e5791b4b3eeba00660961f16b202349000766960c7c8e77b9604
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_arm64.deb
     digest: f09601fbb60184cf2257b12a7eec5e39ae0d8659ae517bb42de686abc791f5a4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_arm64.deb
     digest: 12fa81b09fb516592aedab42ff8e70c82f1373d5d8534e8f2f566047ba3e12b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_arm64.deb
     digest: bec072407ddf1d5993b7449c17872075d8215e45064131da0e7b749de3570eed
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/postgresql-16/libpq5_16.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/postgresql-16/libpq5_16.3-1_arm64.deb
     digest: d1cec167267a17f161a55acebef996462e7a4244d41136d4bd27ea24c7c2faae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
     digest: 3c2fef66a85ca8d8219283c1402eb66500b8587fa4f4495d327515e12b71e710
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 50018565d4dcd103570cac23faf2cf9f4f6cf641cb0abf4cd8bd31f309ce7352
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_arm64.deb
     digest: 503f5c8e330d3b7cf0bf0ced200124c129b4157dce1f4f9ff2d9ee333e30ffa6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: b01151584dd197701a10b0b018a9b93305875dd2ea54902e928482749b40ce4a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: e327d9ef11c5bea99c5a49461aedd4cc7e26f6f768013f0099a2ca648ec899f8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
     digest: 1a53ee6f88e873fcb1a054617b98500f02b09cf0336a96be48f1c3467bc5d777
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
     digest: 1f2ad8c7d25fbd354c77a502f365fce9227af547a0891450fdd82e114c3ea219
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: b64fecf98e2e51ef0a7b4fc256b97a41ee72d24fbcb363308cb5f2155050f183
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
     digest: a3621bb01bd9bdc62bd2896bef51cc01db271694a10cec7841c47c33507fc465
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_arm64.deb
     digest: 4f28fb916cd81a9d1275944c7d7b1215c67c9f11782559c49d289af2c9034d2f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_arm64.deb
     digest: 4e437c832e71179df54f516e31c37fae3436b9c3b0c6900c2649b17c0030788c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 4ab14942ae699f75207feae8b1f7f0469216e4ad2a466149eb04e89d97f08890
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 3ac10cf6a55bb88023a688dec8d6aa6b116df5ffdd30676b8de7ee309e9d3572
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: a20ef808d339999be841908377bbe8c5c53d8cdab9c09472b1baddfaebe6f6a8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: b853bd2864332c035d7d1afcc853f0b0a1f94d5f2bbc26dcd3b70a810083c456
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin11_arm64.deb
     digest: b05a10817b833b8ab7d8e23a25880b7f2c535e36083c28e2cbc79c04da15a968
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 0d2a5d361576643136e5171afa0d24816096e46021f5b03a21cc35e581a69fd0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 519c202277abe8e00ee20f4d5d126a72046c707d6c4b43417a8b1f3ccaa9fbae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_arm64.deb
     digest: f6209c88dcdfeabfe2bd4954c80ef551c8a2dc674a13f91ba018cbb2ade1628f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_arm64.deb
     digest: e1158dab50cf7a78709684e2593b7f5909acbbb15469fa5e8a9bc08af1663203
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_arm64.deb
     digest: 35ed2555ca02d69c8d8ec4c2d571077637e2f5e082eab63a430e4a23e178ffaa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 15e2ee7abc7f1df2f52e3037bcb447792642dba244d0246989325c1bd3d7fcaf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin11_arm64.deb
     digest: d2c7aa12223d1ba629d2f1c94080d4847eec46bfdb63331dace2562c2122e33d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 72d484c76e05e2ae38a65928131d133727a812ae071547bb93ab9c4eff918270
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 42e29811faa894ee7d67cf7f99bedac067c8c8e81f0de08466af2cceef6db024
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 9b50ea79dc265ff87077a3f71f89b320fcd743886c2515612dea6a3d1451d2a0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin11_arm64.deb
     digest: bbee6836064231eb6de4134985079ae0641665e8039ab31f3bce3f472cfa117b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin11_arm64.deb
     digest: ff26aa381464c9f5d67cf7b7ae4ff2fb6160b5788be4a4de8fea764d23345afa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_arm64.deb
     digest: 6580d46c45a2b2a72aead40acfe67184e7e15149ca0737d0a594c11f750daf2c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_arm64.deb
     digest: dfe144682ad4f6fc4c0ca580a9b578686cfc69b079e4ce4703d9f20e38abb01d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_arm64.deb
     digest: e4f5a120e18ddf6f1300a6afa9ac68a3de8d6687f1fdabbd26b2dc472e7c65d7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 67c7ed495663467dc9df34e93460c6fbda20c435be0615fbb09206daae0d7a9c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 9bafa1eae1bd63880e08dea75d2261522383c1cb725e3885c7e3d511129b54ba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 3186c6975e916e090ef7c58553fabb4f0be102355479e9a52794921ea269e086
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 6f8929227deb23d1f6a326e4bef382b0417eb3f44b122734c76fe454b57faea2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 4216fcdfb08fb8a1c4047f87673b1f324b8808fe365ec6e4f9bf372c6644ffd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_arm64.deb
     digest: 79b08b05f818183d0170d8d315b3aca33a2349a3fa77ce3541a2a9f91c73dd68
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_arm64.deb
     digest: 6b089a1257327d7bf8065d636aa9f6365b37b3dafe4ef882c98b633639a7cae1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: e91d5b942949e033d16878ff68f9037a360797c6a23eb6a4ceb457a39a6bec3e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_arm64.deb
     digest: 8191eed7becdeace0c4422bc16c9ec59f2969c83a5289030be44c23c2a64eaf6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
     digest: dfcb32d2b4d90dde2ebd86b2e8376af1f7d5ad9233dc2a943f4144069de82aad
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin9_arm64.deb
     digest: d4b3c9bfbddd4a9fe87cb980897e58b80a1b1b7095a3fd9316762eecb37caf1b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin9_arm64.deb
     digest: 8c680278b290bd7f432316f8a4e22ab42d9a8d746c0a43cccf1f7b8deebcea8a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: b7699f349cf26b8f3445dff1e5b0adb4f37142acb065642bc9fdfe4f7f243a44
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin9_arm64.deb
     digest: a8204c31e6e5f603dbccfb20e11d0f52bbba791a9f3c4a63cc12ad68196ce8b9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 0ec3e9598d80e98be574b9117a97dfc3c0c32e16dbe6bb5ba661876e7061002c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_arm64.deb
     digest: d38dc8bd34b4cf0fe94e16797f662191b91eb9e16f9f0b44bbaaa9b4b4d736f4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libr/librist/librist4_0.2.11+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libr/librist/librist4_0.2.11+dfsg-1_arm64.deb
     digest: 8f3e4470689ced208c9d8253f5f312cc72795d27101adaba0bbb10a274c49b73
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_arm64.deb
     digest: aa09e909d7f1ba4c18ed4aac21d5aac26637731dbc0580e01cd76ee3cb8103c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libsepol/libsepol-dev_3.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libsepol/libsepol-dev_3.5-2_arm64.deb
     digest: c55790b3f227a9f9b3736f40c03c8881adcf60732ce7be9a04c7b79fed7240e4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_arm64.deb
     digest: d989b877a836aa9d00d3d211dec9ecdbd06a1a18bd5683f154ad12c42f8b5bff
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libsodium/libsodium23_1.0.18-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libsodium/libsodium23_1.0.18-1_arm64.deb
     digest: ed58a5ca7a8a4646f503396064852c8a1ec2da9a377a0626deedd2536172fced
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
     digest: ffeba610e1f0ffa299499d88562b65eece4f9865d8810d3a6194ff5d2cd02b38
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_arm64.deb
     digest: bae9a1c57122e44c7a58b3c3572049080ab0a7546ffeb141b0ab81eaf0fdb698
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_arm64.deb
     digest: 359f8bef6d4a77cd5875d210c50dad400ba3cb6625929fc9fbfa5d56d6027a02
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libssh/libssh-4_0.11.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libssh/libssh-4_0.11.3-1_arm64.deb
     digest: d5067b78f7cd1d9bb9fcc22e5a1184c8d39159712cb14797937dfc13921f47d7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
     digest: 6afa3a2ae947564d05b220d89298c7e6e1f875cb05b4ed1a9a450be99a3ba47d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin9_arm64.deb
     digest: 68558cbf05495c0a1c678ea936983a90a2040d51311bd04a6bfbc9a73c45f3ae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
     digest: 41ff44785effab7f081c3d4744d9e9cf25e374c13a00ab8ef93052a0a4d57114
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
     digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tiff/libtiff-dev_4.7.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tiff/libtiff-dev_4.7.1-1deepin1_arm64.deb
     digest: 641cff4491bfd45d04124954e1d142416ffc038f5be0765b7b6a2e2228fec983
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tiff/libtiffxx6_4.7.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tiff/libtiffxx6_4.7.1-1deepin1_arm64.deb
     digest: 034986d3a37a5e59fc1cb0e41b0fa1141ed76c0acff3d09bcacaa268f109f034
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_arm64.deb
     digest: 48481125d3ebb3c27907cc158518e7d3bc25c7c527589b08e7cfb56427a04f9e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
     digest: 790a0e469c3b174d03eb0eb64f4a69ddddd95ddfd4b8daf930e4b4ac7cde179b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/systemd/libudev-dev_255.2-4deepin25_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/systemd/libudev-dev_255.2-4deepin25_arm64.deb
     digest: d72c8c88e272157752f6e206d4fd8787dadeae773c8cdb3b36860b175000accd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libu/libudfread/libudfread0_1.1.2-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libu/libudfread/libudfread0_1.1.2-1_arm64.deb
     digest: 4e25fbdfe08288e6f58cbf5a02a5147f4c2d6f41927020d20cc1a60ce49b5c0c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_arm64.deb
     digest: 03f79776d79c5798181a5c7cbeec4c2af9971b4956e9a574b3d4ea07c742c0a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_arm64.deb
     digest: 1efd5f219b0440fda1a5c2a1b4e05148504576b710f18c374908843d307ac93d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwacom/libwacom-dev_1.12-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwacom/libwacom-dev_1.12-1_arm64.deb
     digest: 3d5a7ebd49f242956b1058290b1a909c4b5e687529d3b4e8530c1556f3d99b40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwacom/libwacom2_1.12-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwacom/libwacom2_1.12-1_arm64.deb
     digest: c07692f2fda707855dbdd2f4586f8f1acf5b9cfc9618db7c08bf3442e4b7af3a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/w/wayland/libwayland-bin_1.23.1-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/w/wayland/libwayland-bin_1.23.1-3_arm64.deb
     digest: 3322bf5f004c10b95c312e95ae90c1bb6bb7b3595caee178d7d02d79397f50ed
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/w/wayland/libwayland-dev_1.23.1-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/w/wayland/libwayland-dev_1.23.1-3_arm64.deb
     digest: d845dfce94123d2388750b820ad1299ac542aae445a29a7aefff300469d88ede
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_arm64.deb
     digest: f783e2d15596e657a9077db7a3dd7e8de84360a27ab504644069df49922a9545
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_arm64.deb
     digest: 9115ed02a3d0d9de956bc1474b608f922aa61feecfd27e267d88e2687caa19b1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libx11/libx11-dev_1.8.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libx11/libx11-dev_1.8.7-1_arm64.deb
     digest: 1c6d4a10271b55eaf39aa83f76851047669a842f2c15b18282f2851bf29644d0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxau/libxau-dev_1.0.9-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxau/libxau-dev_1.0.9-1_arm64.deb
     digest: 28ba4c91230a4d8e3caa43b0897bc56960e5b07eb6e8297ddfe3d57c3514457e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxcb/libxcb1-dev_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxcb/libxcb1-dev_1.15-1_arm64.deb
     digest: f655f75fb5205cb90667bd2e1b1c08ccd93e0f937d1b4124b10afbab5bd4bc54
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_arm64.deb
     digest: 114d2eb11180679b69a9b8727e952f40be5cdfc0ad878d632e727d7b1d5d81d2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_arm64.deb
     digest: 941544912030ac7a4ef2b1c3944932245be753179c8b83f93f2ecce2286ad833
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/z/zeromq3/libzmq5_4.3.5-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/z/zeromq3/libzmq5_4.3.5-1_arm64.deb
     digest: d0604b09daeb5a092bc3b7d77625f48456e3b5a5a3fb660122d36107e8a14ec3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_arm64.deb
     digest: ca9575f6503945c733c4dc2ce78dee09745bdb6eef34f631212d2311e1d635f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
     digest: 68e19fc7f99e8c9d95a0ce2fdde2af187302ab9421cdfe7913d66a8502fa128f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/lsb/lsb-base_11.6_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/lsb/lsb-base_11.6_all.deb
     digest: f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_arm64.deb
     digest: 0e32f0eef7e7f5effe89929ad9a1c14a2838e5033fa9142cf0b3e6bcb81f8573
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/make-dfsg/make_4.4.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/make-dfsg/make_4.4.1-1_arm64.deb
     digest: fd601544bf60cf407d143282c4fb1296842e0cb583308339bde436df40c45b36
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
     digest: 848333f2b40b586ecf8f0db2b6127398d0423867e689937c4427ab15570e5581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
     digest: 729d9b051d2dcda0d0bf51fee21d3b685093314a0b2283926f1eb11f937cb04c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/patch/patch_2.8-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/patch/patch_2.8-2_arm64.deb
     digest: fcc3a3467e4d443f164f0f2ce59e51f546ac2f8d82d0de6fa03e9f942577d144
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_arm64.deb
     digest: 5fd48825ebc6f224e26bc11402982b6767d8a87b1b20bc28ee7dd4106534a52f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pkgconf/pkgconf_2.5.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pkgconf/pkgconf_2.5.1-4_arm64.deb
     digest: b926d80339b80dd7dfab3ed2b9629f1c95c7432379f74eb1db625b1c78c371aa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
     digest: 4b0fffc886401daa9acfb53e2b190528e3fad37a49b989c4fae6715004fda41e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
     digest: dc2acf26739fa1e49d3961179086bf8cc99a18daea02fc75e41a6a954a75da35
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_arm64.deb
     digest: f6b80940ecf252aa3d39b142081548a9edc4f3ac59d49ce2fab548f3ae742341
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 2f22f16ed5d8e7d1feba073e7a804bb4d73a009ea9d822db0ce55742ea842e5a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 8b619d5333cb3d7e3d00995828fb0c511e67b6fceb6f71cad560bc72d43055fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 0fc66ea7adae0fba79c1a8999865003fb60f247e29cf4aad4143586dd4a5078b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin11_arm64.deb
     digest: fea307895b8802b8425f5567f7586a34ad6091e8dc1267d57769849270f90e57
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin11_arm64.deb
     digest: eb834a825e698d1f2c4a736ced2ffa8c62fa4f33a259fc9663d18688261ba84f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin11_arm64.deb
     digest: b982b3e87e0b8f921b1fa2c08cc7a241461258db974e777ee62aa51cf5f270f4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin11_arm64.deb
     digest: ae5a2c7a0b6f2f5e4ec3a03ff30cb69dd45170be3319fbdbc6798f1629831513
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 0ac8a3070a311f790592d2bb37a09346361862aae1b3d3e73ae87314340de717
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 7f1acd58b99d7e89a326af761bbccffa8c2f4fd996c6b0fdae675e7acbd33acd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 3b0767c6656964e82c310af8de07d91945125474e1bd6a3d92af76169462ff1a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_arm64.deb
     digest: 0a4a4e7f77ba792604bb9563b61689c8311a746bc4d5e2c1a10b80fbd9f91785
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin11_arm64.deb
     digest: e240a2114fc0f707de9f1c9c87abf489619a05f55d6d2087107ac3f3abf041fa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_arm64.deb
     digest: 18ab6b266e8492e2203479d773b546a203188b718178a69208d4c213be9fdc91
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_arm64.deb
     digest: 0165c450a2abf4ec099df4a3e7e5d1cd253fb3ebef7f23d8a28a95763f14e480
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 9ba87913324adaf07b3072b26a19887b347adb858d710d67f783f38cc6fd29ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 5dcbf8f4af0def0d7b9c28d170a4fde882efe33c884b5ab3dac1029a490465c4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 73d408f4ee428f0985ce766566b55d7d6fb711f08a2f4ed0ca4be7971e3734c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 176cc3fc15b2a0cce2a94321e03c16db394e92493769a4428220a32656a2aaea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.43_arm64.deb
-    digest: d7f108f23d97a4df799388719e9485ca920cdc48e6d4957725dcebf14d4bf494
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.44_arm64.deb
+    digest: b7fe872d11956ffde70a8eff2d27e5c885b861a182cdab6303b70261e206e51e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 636aa4737dd54fa0d23a22938a1ea2d5bea7fccb7ed7ccc545072205221d4c68
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin11_arm64.deb
     digest: b865d00118ba924222e4785806a0b59edc2da32eb4b0be1334fb7566b9be687a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin11_arm64.deb
     digest: d2400d77b81045757d4473de66a6fbf8eb3062e3757f2d6b1ec461c5be9fb0e6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 110bce4ebb255be4bcab3ca53bc9024b65db9490238f6b45d0fcc9481589da0e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 058ba43a555d6d87a830a85ca094159c43f90927912d55f8f3f71f8bc3e378c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 68eb7fd92062f826e7e237933c0403f8d1e410dc6a73f383598b202db5da9334
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 7ed3d8b83d42d4660ff0215b23b9024254156a19b86ea97c11680c0eda0dc7b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 108dbdccfd73550c30b3cec29175f858a54f3af1e89e5e6ecb564d40eb671fd1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 2287690cef187c957cfe6b799865a7a8782f581e00282ac1a5aa8f62dc1075bb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 91354b8f26931ae7a873581ec4fd1ea74809718f1158aa8b51df9707518e70d8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 30730729b5b83e6881530a059252eb0ed8e0384a2f3ad524f5e366a00eb46136
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_arm64.deb
     digest: 18c3716aa0b734ca7d22e0ba8e51df49ad55c2c76726ee1e4a638007e3044e60
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 0557795a7ddee12b1ccb77c837b47f7de3469a11ed01cb8093c7938699459eaf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 28f9e916564cb36156b02cd907ce2c8dbda89841ed8ec1e80d4861d5f975cc0c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_arm64.deb
     digest: 9b681bb49432f5a20b98ad7939c4102975f5952efc7dc7ef1058d3ff7a0417bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin9_arm64.deb
     digest: 04d311740a1372296b8f7590471aca7e252fb9f175ae92f32750959a9974fa3c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin9_arm64.deb
     digest: 537408f45b16b4f140111ecfde8e813f2936956b711c38bafa7821364f1525b3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 9e8abd40b9edbaa38674d367be309a8b0409ff15aa2b76b0660c35738399e46c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_arm64.deb
     digest: f16c25091859915e16ec9079cf2e640f789fd896b55aa43c4a2b00d7df88c864
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_arm64.deb
     digest: d2fb36d7fceab313a833148a01a0a9da8dd28ae4363dd2391001092cf15019e6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_arm64.deb
     digest: f25523039fc335e2beb3a6082fcce6f9347de89d1bbcfec00d66350d97068b65
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 0a941aef322b1daa86496d808ac68402743bed07f62af7a5685627519d874514
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin11_arm64.deb
     digest: a8c77834a37db73d4f0054acaf26d7b7db63288938bff2dd2c610d96183caa7e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 349db53f4177ebcf0f4c4456a59b626f89cb93bdb62ef5add45fee33784a1b3c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin11_arm64.deb
     digest: e027589314a39a3c7d6ab332091dec2a19ff8aa30cb58ba4535f056e39b758ae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
     digest: 7240dfd58e097adaa152de41b86457f9933cab56d919b7fbaffa783da48ddc4a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_arm64.deb
     digest: d1c40016e70c0d9575429adb35aea04328b2b051d0c41e801efc0ca1acf75308
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_arm64.deb
     digest: f5599ff2546d1f99133d853e039e11193f45e5654f2bcb835e26218b52dd15e9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
     digest: b726420f3a1803c2d33e714cd29b9eb757aef9a607a42d4d9a4257331d30b4c2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_arm64.deb
     digest: d024d7f1dc80124397a3d4a41f4d2015cc72819d7933c0e5ac1cc2331b1ae548
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 0c1909606f4c351a2f39c3d0739038d835882560321237cdf11985f5edc0d077
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin11_arm64.deb
     digest: 0a178cdfc646636bc918064da1f61408e775a59024ef3f4258fe25b31ed4e04e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_arm64.deb
     digest: 0fba54761bbeaa804bdf1a6239f727986c287308e4f0ab5dd48425f52729f22d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_arm64.deb
     digest: b9cff1d9eac542c46a108dd15a20163fdc53abe14fcf21f6be90f98bd14f8127
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_arm64.deb
     digest: 3815c4d7c65d592eb364070ff3e8aeb1e5e1977e3652d5f266bb02cabcae0f87
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_arm64.deb
     digest: 096625f80d868ea9fa76a664ec8d0b821d696e6ed0599be4f3c23e94e1f5b9bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_arm64.deb
     digest: e1c490bdcffce0b664685edc6d97151e7aff8018c3cadd8f1583fa6fa20228cc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_arm64.deb
     digest: bc8717ff810872db3809ad67690c5359656b1780dc410c78c82d69cf3c19c711
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_arm64.deb
     digest: 841e0c1addd40a42a1013e897162d217c27415ea2dd1ebcaed7b61b5de1c8944
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_arm64.deb
     digest: 041a22c18eab9afce1af06a67a4e535ff870edd5404601c75fecdf091120ff95
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_arm64.deb
     digest: a6351936c0c2deeeb6fb3655429b0fa42b24c6d59b7f145f7d19ca7032b1bb68
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
     digest: dbfa88dae0e66fa60e6558fa80242bb78be8dec5b37ea449f85826b1b48cf25c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin9_arm64.deb
     digest: 7f707545b0d915373378754fc3de837e6316bbeabf8ee66ae0d68700b85186c9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin9_arm64.deb
     digest: ffd96a941b2e0dc1d1513bc2b5c441414d0c3e733263966c6ba111887d4afb2a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin9_arm64.deb
     digest: 331da06cc563d6a5e3167c5a80021b535c1ffde8c67cbdbce5cd4e7a5c7595d0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin9_arm64.deb
     digest: eeb7a6a7f786d428b87eb9a9695d4e5eef0f823d1c253d211a77a0d16d628ee6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
     digest: e70bbe5b35aa1009f8d3e8d58634052977864bad1d854230add6758ef238b1bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_arm64.deb
     digest: ea5d963bc7051ceb4b9ca5c0d1bdef293f67bf8bc40e80586cbf09c8beb1db8e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
     digest: aae8ac2b6d3198d297d430cdb97e556365be2ff46d06525008ce071d97ac69c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/uos-license-content/uos-license-content_2.0.7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/uos-license-content/uos-license-content_2.0.7_arm64.deb
     digest: 336dca2068ac0e9a47cdd3ef494eaa9cb0066a31b19322c22e90e02362edf93b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_arm64.deb
     digest: 425f15ff8656cbf9312b2fa0f18c4cf77855c0d0955db4515c0406ce801ff6d1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
     digest: 29a1888f6b7be54992868b36050c68d6063820ae6c4a2e09ffa2317a7e0b6d6f

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 25.2.2.8
+  version: 25.2.2.9
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -13,7 +13,7 @@ build: |
   bash -e build.bash
 
 sources:
-  # linglong:gen_deb_source sources amd64 http://10.20.64.92:8080/crimson_runtime/stable_20260617 stable main
+  # linglong:gen_deb_source sources amd64 http://10.20.64.92:8080/crimson_runtime/stable_20260623 stable main
   # source package qt6-base
   # linglong:gen_deb_source install libqt6concurrent6
   # linglong:gen_deb_source install libqt6core6
@@ -179,815 +179,815 @@ sources:
   # source package uos-license-content
   # linglong:gen_deb_source install uos-license-content
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_amd64.deb
     digest: 8b5df0b28f8a7cfc63a1ba4ac369f09a66e19d47a462c4bc8fa8bc552f18a714
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dbus-broker/dbus-broker_29-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dbus-broker/dbus-broker_29-3_amd64.deb
     digest: 68ff1baedb2f4ced1ff5d2f9c3e59bd21e741b7710931e0539c89ef5951df8ba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt5integration/dde-qt6integration_6.7.43_amd64.deb
-    digest: 3227e9670c2da767232fede832e426d620b67d4745294f57ff35732cccbb80ba
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt5integration/dde-qt6integration_6.7.44_amd64.deb
+    digest: b72adf2866dd0b813eadfdaee609b0b95230beacff8693f6e362e1881f6c704b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.43_amd64.deb
-    digest: 4e3baa7840305621cccc242945de32aea7041afb12569781e48dcac4514fbaaa
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.44_amd64.deb
+    digest: 0da7d27bbe04335fced15cb15865d547f59f2bd5b9ad7a77f774a21f331fa3b0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_amd64.deb
     digest: 8502f9dda05684b5114e9497d55e057aa3911f5b03e27db317a211f4bc3389fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
     digest: ec9d003e1996d9dd70c29c8b1d1ecbb0df0523cb64eb617e2e958fe59ef3110a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
     digest: ad27e359a1fe3485255ce3c17eab99ae42ce1aa03acd67e45a2751710dc463c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.43_amd64.deb
-    digest: 76d44c02c288a5c15df2d964acb2e89742cdc6332556f36af88ee11d7a2ca41a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.44_amd64.deb
+    digest: 370e286e6d0ca0757f1959e88336ac196725c31f685538e95c56b8fe88e0a28e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.8-2deepin3+rb1_amd64.deb
-    digest: afcdd83e4141aa0c50986d751011151ac171dd2272054703bba20fd5b8a5562a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.9-1_amd64.deb
+    digest: 50d88ef6e58dfdfaa8dce68cfbde3823524bf9e38bb906d68705738feb12baf6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
     digest: fafd08c872d1279aa0bde2e0bdf40a57721961934c0593352b6a2c551aa232a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
     digest: ef932bad267f9d4d49c0c376ae1d0fc1a9b595054f8450d42b2a0d6621bc7084
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_amd64.deb
     digest: 3deeaae0728e06b5746cab0b8f621986d6355ec09ca1130719c7be1900b1171b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin9_amd64.deb
     digest: d70bb3bf85bfae53dcd17b52fa75a612400debe0c18564026d41e5c1c143dcc1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
     digest: ad82b2de93cc49cdf37c861b03275245318b1555255639e5e805cf612a40171e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_amd64.deb
     digest: 9b9bd06169d7b6d031810f25f45a734052ebecab866a88ed1b2610fccf2fd739
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_amd64.deb
     digest: 563f4d3b275996192a906b926390435bb3e444294f8766b8db5ba66f199db55d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/b/brotli/libbrotli-dev_1.1.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/b/brotli/libbrotli-dev_1.1.0-2_amd64.deb
     digest: 87226cff96c560b3ea8b15110f7f2b00047b0cc9dd29c9fdbc372b4d9154de80
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_amd64.deb
     digest: 60e1d9cbac4fafa4f7823e6495212ec02805997e64dead0f40de1d86ff138d41
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/capstone/libcapstone5_5.0.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/capstone/libcapstone5_5.0.3-1_amd64.deb
     digest: 0e6b1c94b28127dbb067f7ded642625abd26fac8bce528aa9bad37e5b66836f8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_amd64.deb
     digest: 1ee2dbafa2c331d58cf10cdf546c760d7a734c5d9fab1b16d2e04e51f6e38623
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_amd64.deb
     digest: 0c0ac88efe846e4cccd84c896722e981be3a276b984541a4aeb67b1a97a86100
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_amd64.deb
     digest: 88e484221866f3b51022b4e8dcd3d4a2f156e2de8118603f266d90aacaecb759
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_amd64.deb
     digest: 5816b1f4f5a5f2cce5737ea3c39525189212f4fcc955e4f2e3c5ad26d887964c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_amd64.deb
     digest: db9bca0c6cc68db2c0f31712b94c36746307cc99a1f8a7e55a02c0d3c1ccea40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_amd64.deb
     digest: e46088a05f1b65f8ea777dd2b739c8dff9e37606b16ad047fdda36642dc4bc58
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_amd64.deb
     digest: 07722256ffc3605844dc08530aca547143771af140f142896fcecd90bcd83655
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
     digest: e6c6d028a74d0a752ae638ec19b8239f404c36d676c7569936f31000d25a75f4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
     digest: 5ac1e65112a190dfca99abf002e3e3f0ee033919b7b65cef5e3637ff1821cc9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcore/libdtk6core-bin_6.7.43_amd64.deb
-    digest: e0ffd9fe1c85bfbedeb4392df0f831d8ff55f135eead706b8e81e288970bae8c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcore/libdtk6core-bin_6.7.44_amd64.deb
+    digest: 20115a794fbeb628e0bd064ef8cfc460e8bf67a081d74db3a6e80c1f9fb783ce
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcore/libdtk6core-dev_6.7.43_amd64.deb
-    digest: b5307b44bad934e197a199a0458eca8e4c20d56df0730c81db8eac571f15f8d1
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcore/libdtk6core-dev_6.7.44_amd64.deb
+    digest: 8d1ac95cafc556ae77d4e2633f6871d536aca99e4db41a8d5c688cb140123618
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcore/libdtk6core_6.7.43_amd64.deb
-    digest: ed85b6815116c5c3a6ffd0fc22b1364d4ea54ca4acdab9746ec25508d3f66337
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcore/libdtk6core_6.7.44_amd64.deb
+    digest: e331f10a04ff87caa6098c7708aa97d6a1a328b474abe43ad83d18d129b9b7a6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.43_amd64.deb
-    digest: cfec4487fd20cdc9965f2baebc4f2d40481131c748efb63cae66ece64a04dfee
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.44_amd64.deb
+    digest: c55f74dcfa55dd3c64db9c503f8207f94783cfc3ad1e356644ac589bde889b11
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.43_amd64.deb
-    digest: 1cf5a17f4b90bab7bba7e54a29e08dde371e65a3cb2fcd64608e311ea1727d75
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.44_amd64.deb
+    digest: 89e27d4014a06dcafdd2d97441867f580145400b7f83f2682c8aeb6122f0b745
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkgui/libdtk6gui-bin_6.7.43_amd64.deb
-    digest: 4bf89b7b149616d98743afa150561cb3aa25705d33c132f1c9f24c76683e5ab8
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkgui/libdtk6gui-bin_6.7.44_amd64.deb
+    digest: 25ea4edc7808c79573abca2ff0ba0f13c915c02b9dfa9df5a5a80bc75da4d117
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkgui/libdtk6gui-dev_6.7.43_amd64.deb
-    digest: e6105f8215c74e249ff1e97ff2578c6993e60f4c55e897df720e181264c29a29
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkgui/libdtk6gui-dev_6.7.44_amd64.deb
+    digest: cb485f7980f92580d88ebbff8891a3b5e1b6ec93f9765eecc0b16c27783c711d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkgui/libdtk6gui_6.7.43_amd64.deb
-    digest: 94f2a76bcb343b9ac1da3efbb2d4f61b983bac8df7adce56a8ba6cfdbc5d4654
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkgui/libdtk6gui_6.7.44_amd64.deb
+    digest: a569993659a0b623c1f4b93861c628366f96cba726ba57aac2ce6d0a7893fdb5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtklog/libdtk6log-dev_6.7.43_amd64.deb
-    digest: 1351e8f6219625161694f72aa9fe9f828921e0fde7f96bba05a7c917cd3d4feb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtklog/libdtk6log-dev_6.7.44_amd64.deb
+    digest: 0d94ae3458fd93ee8c848f6c23702c7c7f5471232d7f56334106a217d84e670c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtklog/libdtk6log_6.7.43_amd64.deb
-    digest: bedf821195ebd23e223eb2e4b02379e950602d6e8f9fa0d572d10cd9f350ef83
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtklog/libdtk6log_6.7.44_amd64.deb
+    digest: 2d405428a8f20fd12f45c224b76ab80f363251f33b63c39e46be88746b592774
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.43_amd64.deb
-    digest: 0553924eadaff5d67a2ea056976d6a9b64673794739c5b376549af7d27fc0039
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.44_amd64.deb
+    digest: 58574ec7143786c89ceccb1fe1dd35f9d90ed9fdd38586d35b22b7e73d1bcd23
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.43_amd64.deb
-    digest: 40698a8fb0d01470715040ac1138604907eac6f77249bef84408863e1de6227c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.44_amd64.deb
+    digest: 35423867de3aa8516d33b071110fb6f70d27020ffc33ad8dabdfa081d305e621
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkwidget/libdtk6widget_6.7.43_amd64.deb
-    digest: a8462711b6d5da745b2e93180b88d91d3451074aa52fdd9e77fbc22aeb70278d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkwidget/libdtk6widget_6.7.44_amd64.deb
+    digest: aae17de27ab3bbd381cc7522b18fc56925777692b0a37164b54eddb051e77976
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.43_amd64.deb
-    digest: f9ef6daf0e399d857307d11e08da870ad5787ae3c8c27d7aeeee05ab6ba2462a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.44_amd64.deb
+    digest: faaf05232211e3f0fb3e8ffec5f0abc50f596e846194698eb82ce3def239fe60
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcommon/libdtkdata_6.7.43_amd64.deb
-    digest: 9b43239125810e0e8a997e040e19ddbe93d957002fb0a849bc0cffc4d5404c68
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcommon/libdtkdata_6.7.44_amd64.deb
+    digest: eec45a0861b66a52fdca8cacd2770998487ae1615992c3abc33352d4a28dad6f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_amd64.deb
     digest: 97ad0dfcf56a9bbd5a2e768603d686cd1fafb9164584bd1662fd95b49d0a9c4c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_amd64.deb
     digest: 5d6b39df3bfafd42d3de1d445c13f5fc4de2a4c772b4e7a2663bd4af573a3870
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/e/expat/libexpat1-dev_2.7.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/e/expat/libexpat1-dev_2.7.4-1_amd64.deb
     digest: c32c7230aa02e0b140e90339b660525e7ecd1aa2d9d52b968353f48e5fb63b42
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_amd64.deb
     digest: 69c8f541c96059330b8b59f110fc1501594f72c291585c04997795f0b24ba105
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.8-2deepin3+rb1_all.deb
-    digest: c5323498567c4b1fd58c620d024a153dc9ed17de13291d25e41f89a214007b62
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.9-1_all.deb
+    digest: 095f6c357e994b15d51e9cf85722cbdf80f821a8ba2e5b2310fb9a40bb2529b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.8-2deepin3+rb1_amd64.deb
-    digest: e24bfbc28cfa374cf094bc4f71db8cac5090e78b0fdcf930af08b8f54e14b85a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.9-1_amd64.deb
+    digest: 47c84bb370af22a679d2a7dc065cb06516a830aef28fdea3cd9c244d355d0b8d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.8-2deepin3+rb1_amd64.deb
-    digest: 31325e9bbcb1c37e32e0865ad55d2e6ee1bd4dced9cb8ae8588902e4f06d5904
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.9-1_amd64.deb
+    digest: fc68138bd7077daf6b8bab0dce69a8abddfa6b8b62bb24c29010e361ffde80e9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin1_amd64.deb
     digest: 32a383e376ed59cb776cd7df67a8f0d0534cb236c00461818d177aa920dacb02
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
     digest: eadc61825e77bad028fd5eff398ac0e13da7a08870261058525d3f620d90cb7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/flite/libflite1_2.2-7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/flite/libflite1_2.2-7_amd64.deb
     digest: 8851ce503276f63416a9f1776fe8051b87c2fafcb3ed0990bd4e1572b4ad3ec8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_amd64.deb
     digest: 00a674b9b4c7034dbda109a463cfc89e67f803b2fba83965992754a79e948fb2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_amd64.deb
     digest: c43e1ec347d6fa3a1c42b273f9fdd736996f043e4a24dee4be0516c05926321a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_amd64.deb
     digest: 006a8d5b94347c80f13475dfc3fef138932400a38bd54f5dc762758f30e0cddd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_amd64.deb
     digest: 85582a97b11296a1012fbc5df9aca47131b1c799aed5069124bbda1269adb13f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_amd64.deb
     digest: 9555387119d2c7118202da7424f3d95a358843cb6e3369135979bf3fb1e7586e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_amd64.deb
     digest: 21242e99b2d8615b9c24401c65525603670744aca8c2ba08d9621ea8dccd07a0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_amd64.deb
     digest: ac3c1fd8eb08e6be3a3cb14b8ac8ee33c233bcf5b0900e48026e8fd2c53ab54b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_amd64.deb
     digest: 5b8281d799f1b3844524c1baa475e4876665b4d6062800655e180586dc0015bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_amd64.deb
     digest: 6f185c6ac2987d5d8ac0f81be7f0377ac34c00ba45ba8d206ae7ef5888bbca00
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_amd64.deb
     digest: dee4a03abaafa64f9c5c85b107d603f78957506a58f5a3d7a9ca50654cc9742e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libgudev/libgudev-1.0-0_238-6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libgudev/libgudev-1.0-0_238-6_amd64.deb
     digest: 562fb1c4a945754f1a134aaff3d718533d8b91537862397c23fcdfdce30b13cf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_amd64.deb
     digest: 056919a20ff7d1c9c018efddbc7c568c5362f439d371aebd7838eb89ea0ccc0b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_amd64.deb
     digest: b4036cefbbc4f6a5f73f6ac19d3065c52dc6b923691268c5b3032971465c35ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_amd64.deb
     digest: 053103d5bb15e093e098dff38967470132d0d2ac700282dac521965d61d63c37
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_amd64.deb
     digest: f960b005d701ef23c211a2b5d07708669114b4da523cd3d4996037ddbc931121
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_amd64.deb
     digest: 41620db50b4f194759575e4b069c4bdc7f788e5a8e3a620d00345706fb01eb55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_amd64.deb
     digest: 7ce8d535aa0768ca1cf24178b956b3bbbc82cca19ce4bbe91ab32c36038ae336
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_amd64.deb
     digest: fbc596effd2b0a596b71e306d120e5b660bd478c8c9d24e47c61b4ce2db33d27
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_amd64.deb
     digest: 126fa110768ecfbb4569ddb66d53621f7007dcefa1234e0ba4f37e364903a607
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_amd64.deb
     digest: 9bf199c57795a3e4c8e7cce1ef1803e32e9d31fc7cb82b5db8275f654e19b655
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_amd64.deb
     digest: 44596cdf0fefdc6412af3e1e0d0a4bdee4762d348cdf3818a2cca0daab437285
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_amd64.deb
     digest: 0e611c43cc8cee4b31dd530ef21f4efbb16caab257685a770b612146e18a6b8b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_amd64.deb
     digest: a81ad1bcbf76123a98aca07e8bb02b9e21a592dfdc7513810335c18b471424b4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_amd64.deb
     digest: 3e6e0b346583febf9b616ea25c183c85f4821335a94f9cfd1d51011ec00ff3cc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/md4c/libmd4c0_0.4.8-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/md4c/libmd4c0_0.4.8-1_amd64.deb
     digest: 9f1630409adb3464aa42afc519d2163a7741d152b53c937eddea55b9fb6fb10a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_amd64.deb
     digest: 256423c8e3c4afcbdf72973db84b1e919187b65955c685ee16f9a5635d436943
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_amd64.deb
     digest: 4032c2da0fabf1e0cbe6f7adec0e62a4cd0dafd11aee37ee3d2832b645ad733a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_amd64.deb
     digest: 92553337dcd1837205a4f136419b0cf40956e0975a938ad8e8e7b586659d0e46
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mtdev/libmtdev1_1.1.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mtdev/libmtdev1_1.1.6-1_amd64.deb
     digest: 28686d830a44272e63013aae1e508f0f767ea28c2a4856d6c6724e11b2a6f93e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_amd64.deb
     digest: 5b552cdd40095bd94c6276021dfc5360f2a6289aa94f155ab3ab3daaef341c1d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
     digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_amd64.deb
     digest: f38475bd848c5e0f4481bb11a55779bcf37d263523f5b7a7625511e7202236b0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_amd64.deb
     digest: 178ad33f72e1905c6d777a680fad42295608be7a6f8f95dfe5f2f27dbfcd5505
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_amd64.deb
     digest: a037354a8429c3c32358ee745ab5dfe3d92cc60b74fa68d6355e8b63ce100fcc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pcre2/libpcre2-32-0_10.46-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pcre2/libpcre2-32-0_10.46-1_amd64.deb
     digest: 97811098f7fc09c7cf0f3e1b5bdd9812af8aa5793039e8b678bfeb8d57b9750d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pcre2/libpcre2-dev_10.46-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pcre2/libpcre2-dev_10.46-1_amd64.deb
     digest: f1850c35ce5b42ad77153650ea66f8611b2c171b5b8761870f938795f517920f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pcre2/libpcre2-posix3_10.46-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pcre2/libpcre2-posix3_10.46-1_amd64.deb
     digest: d4e0f487adebdfeb320945153d10ec21f094eb4aea3c806db768ab89f8da86eb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_amd64.deb
     digest: b8f9b921c681e6c08abd8d452489762dc8ec3234e058407757f4f383ba2a01c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_amd64.deb
     digest: 9faa99ec2ae5dc678bde09299b6dde1c7eb5c5ebc27039abad8a626948119b7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_amd64.deb
     digest: 774b3b62c14cb57fecd209006fb73282903f14b8a322e9ed6be0b7b6645def2f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/postgresql-16/libpq5_16.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/postgresql-16/libpq5_16.3-1_amd64.deb
     digest: f458fa7e81f3f405b122df4a87d65d93446476b0e60da81ea8062235513df9eb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
     digest: 8be922fba920a96d098288da4fa5f1d5dfb778b362d7a26ed738014305aa3787
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 55a196ff4bec5823b6a575786527ce5e3986828b51babd9e588bea8a155ccb8c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_amd64.deb
     digest: ab7b2830d58cf362c4f33c7252a7ffe5130893560082eb6a43a9d208e4407e84
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: f38eeba0a1b17444653ec405895b293a58ba9243b19cb4d769b9257b39c8305f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 4e746495d4b45b99d7631e7af5a3c828ad66b07f29ac539d31eab07d5cdf30d7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
     digest: fca05a0b5e2a9e79d70fb282e4fd5be1d8c0e5218bb359e5985c47a3d886905b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
     digest: a7cdf3370adfc03459761b96ea0701a32374981e41d875338cf21f68e32e31fb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 48b849c1cfa4d1c125e3e74712fde44449b82d1069a0e1c9f1bc8a6bd0152a3b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
     digest: 1c3db1f054f82d7c0957edb0e59a084a81a7c3df5c43357f479accbf9df075e5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_amd64.deb
     digest: dbc187ef7ae9fc30a2880002a2cc4bfa132f83dc7c2abff91b480bec6a8fd187
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_amd64.deb
     digest: d754dd297c4bd2b2a93ef7d7bec5b1929a8f06a6b35ded515e01331633d1204d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: a6c55c0cc02b525308a1947845429bb3edf3d59744a3388ea6cac88d6a3ed4a1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: a6c7a015d5f7a2fdffcd889fee78e5da99bf0ad130f47a20133fb39301284949
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 7ac0ebc7a2dae4913cad047b7e50f263060fb78ca4fa5abdb8590d49928ef697
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 6e5e294b19978fc4cd73d026cb49caa0c24203ad4a248b19bdee3501056ab2d1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 4ab5f10a3b8580b263199414e5967d848ca695227145b18d90f53c4722a79e7a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin11_amd64.deb
     digest: c62b3954253d2050170c368de79e797ed582d02221f7e84570fa163c22b67279
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 2b69e5e08781b90e4329ccb163eab3ca9f2d8e89f5d223e327a8311bdcf60c7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_amd64.deb
     digest: 824c7f5ea18c56c178f06c891eb718c939fc0a4d387dc55c048b4b234a21017c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_amd64.deb
     digest: 48df47dc9dab619440be10b81db1a6d75c4e86a6f0b74b98f3d92f6cf97f3894
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_amd64.deb
     digest: ae1f26a30324396caf7f9b2bfe6194610e91d719d9a2b2d53be96426ebb553ef
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 80b2796e3d25c6b46c814f49c1c36af5531ab479a83cf16a30b689f3b1e6e69c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 75fd298768c7fda77a2bd83847babb47b3ccddd9381ce16423dee4ff17339182
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin11_amd64.deb
     digest: c6edf902bdf5291c0ef4f04910e438bd4a1757c47c33572cbf6a5acd50e26983
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin11_amd64.deb
     digest: f58922086ee84e51a4c0f5a7b6f4c80f8ab7d41566207852f396a1f40b91f987
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 4439f7a1ac6d6c37fe6c1b281add50298b4c6084b19696f4a0f910155774f257
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 9aea6c205086140d0cf5c7ffd7550016ea8e72f10fb9f430cadb3d82ace6b0ae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 3f24c881d0966a6c0f22a534268157570f8b74bc60de1395775635798ed88b01
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_amd64.deb
     digest: 4e5dc0e41f8c49451b4595e605ddbe74d5cb4fca3100d26b552aa6a0931d575c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_amd64.deb
     digest: 73c0e26ebd541bd02158cf6265fcc55b16b7148f9db0a4130b7d7bb50a83978a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 81daa7ac7482425dadbc91b3e4a0b1d3937bbef908a676ab6387868399f27220
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_amd64.deb
     digest: e0a7e4c340f2cf2a3678f5b66fd7636a1b94628e5095f82c530d7e67393a756e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_amd64.deb
     digest: ee6d7effa7144c000e0c4f735718f3778803c5fe1a164b780d5c8dcc573567a3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 0318d3ff15107f5c3e308712ce30a7112e678f1ecfccc2032079eb271d58bc9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 2c370a18a9c6a42a8283cdc53863769de52431cabd00b196b98608bb82234927
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 992afc0c3df2e0dec237c134b5e5de9fd3f06978aeb1cd0a6ba99a33a8a1c57c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_amd64.deb
     digest: 19b8be6556d17e4cda36289e75f6f36a6754fcc563ab38b7b12eec44e9bc9cc8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_amd64.deb
     digest: d20ac9a0cb3fb7be175dc8d1594db89ad9a0c2a49184a92cb3fab9e4bc7c8ffe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: f91971028658594b79a6304949a40eeca5a050fca4f33e75fc66f387f5235b81
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_amd64.deb
     digest: b31569eb5340aa263ba7d526406c50d7877c94031bcfe9a6da22da6b794a934a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
     digest: fccec1dfae75e5e95ee0c23f7b705c78e84c9646bbb7e2f929ae1bbfbef6e5a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin9_amd64.deb
     digest: 174c76af4979f20f295af96e9bd87beec3df8c4ee3dcb5a90aaa691cc4a15f81
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin9_amd64.deb
     digest: 046aa45571b2b05b2d213fc663eeb4bdc15fb79c125baaed4c203313e3a90821
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 6dbeda2bff5ba28e56da3ea7f5930be7c749948288296f8de899e5ff4d4431d6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin9_amd64.deb
     digest: 3e25e1ce0a53a814a3fb0c86c84d253c4307c8bedff3cae691234eb5476bfeaf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 547daa2881ec2cfae38d901ede4cd317f35445b2454c939696aa99eddd7e8853
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_amd64.deb
     digest: 4b74d4425bcb1d23d7763e62cb1c9f2be712d9f92e46542151125ba96d623164
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libr/librist/librist4_0.2.11+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libr/librist/librist4_0.2.11+dfsg-1_amd64.deb
     digest: 620c2049aec638274e02b3cfaac1398e1f67a6a1a76fcb13383542eb4637648f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_amd64.deb
     digest: f7dfdd9e463828cff8e624ceda7f13cc68f2c9d2e72b27dc7e7315e1193b7d92
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libsepol/libsepol-dev_3.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libsepol/libsepol-dev_3.5-2_amd64.deb
     digest: 4a1b7141086a540294dfc0df7eb707f2ef1e57d2a2f4b30f80821164d0f97b7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_amd64.deb
     digest: 7af3357f80d57fdc31a26596f9e93f0218a625929822228d312498cabdcea72e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libsodium/libsodium23_1.0.18-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libsodium/libsodium23_1.0.18-1_amd64.deb
     digest: b16ee914acaaad0cb1c062370f30934b76e401350bd531d169e5838927c4da30
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
     digest: 44381cd9ad35fa6ffa7a0b3e27611011602bb32093efaf0c80117dc9f97a371b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_amd64.deb
     digest: a5b9b34ea8699849e17a2e4c7428f5dabbda217a85ca9f2cc47e4ce6e0d250b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_amd64.deb
     digest: cda4bbbcedb3ddd9b6722acabb811b95d1a6573a60ad7e6fedfbccac843bf8f2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libssh/libssh-4_0.11.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libssh/libssh-4_0.11.3-1_amd64.deb
     digest: a525b7a475d9ef111dd4b9af0baa4eb5a06a15b008b5a9e27f754a5ee091eed7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
     digest: b0e9783da04f53ba8da97660523021322c4477059c63d3684fab283b7f9aef9c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin9_amd64.deb
     digest: 3f438a8757487e4e5a9b99d6f1555c63142a23ec215577210602c94597e8d307
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
     digest: bbaacdcbf341e500cd8fbe0dfb75fc98156b0a5abf94e43105bb5f745c3168dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
     digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tiff/libtiff-dev_4.7.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tiff/libtiff-dev_4.7.1-1deepin1_amd64.deb
     digest: d1eda91af2c50ab1a627fb3a631885c58b0c8173eba76342af4e85c3f647185d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tiff/libtiffxx6_4.7.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tiff/libtiffxx6_4.7.1-1deepin1_amd64.deb
     digest: 756eb3dd1d449ecd8a253f144f108287e4db4e1f7850f77ad68a335b1c30dc42
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_amd64.deb
     digest: 1da0a72adec71588a6ac641b6f60ce39aeaeaf6771bcd2386b7dd33ad49b0548
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
     digest: d7c7fffd808cd0b765d2287b98bea752d740994788dbf90de6db4f9710e41162
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/systemd/libudev-dev_255.2-4deepin25_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/systemd/libudev-dev_255.2-4deepin25_amd64.deb
     digest: 1c96a6d7669182ba07c80576b8a7ecab8f28259232741d48cf96dae59979598f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libu/libudfread/libudfread0_1.1.2-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libu/libudfread/libudfread0_1.1.2-1_amd64.deb
     digest: 5ebb4a61642a553212842e52f9bcca0bcdf2fa47f95d8d1a4b30d6096dbda8e9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_amd64.deb
     digest: 50a8cfed14d73f5e15fe13de7faae7d05b5e3a5afa79bac1ed373cf8487213a1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_amd64.deb
     digest: 24e268d97e22c4ed71c91201fb5d54f8b4b8689cccd032f11bb4faa1143bae04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwacom/libwacom-dev_1.12-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwacom/libwacom-dev_1.12-1_amd64.deb
     digest: 2e107e0a55003a2c223c792b5d505e566c553c42b0f6acc98f927f1a88bf4c2d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwacom/libwacom2_1.12-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwacom/libwacom2_1.12-1_amd64.deb
     digest: 2e0eb22e108ff3de178a570dcd21ab3d6cc16f6baf94bec37595008786789280
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/w/wayland/libwayland-bin_1.23.1-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/w/wayland/libwayland-bin_1.23.1-3_amd64.deb
     digest: 452bdd1fa61105c0e7a8aed8afbceac7a3c3cc07983ffec146f77581f48ac713
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/w/wayland/libwayland-dev_1.23.1-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/w/wayland/libwayland-dev_1.23.1-3_amd64.deb
     digest: 475c2fc3207e28a3d5c54b81b313b00222fd52042fb2beb3cfe7814dd40bceea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_amd64.deb
     digest: 0c60cd19f18fbd0cf299480c7e7cfcb7451e6b1b05dc8f2d5cae1cd248e4bc5f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_amd64.deb
     digest: 26d6ff4ed6bf1da7fe3eafe2514ef5c04a8792381b35e3bd3745fab1b6347246
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libx11/libx11-dev_1.8.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libx11/libx11-dev_1.8.7-1_amd64.deb
     digest: 93ec6c1345900f791549c12440757ba08e756379278bd6fe5133e6690c544621
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxau/libxau-dev_1.0.9-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxau/libxau-dev_1.0.9-1_amd64.deb
     digest: 784b6358825482c6b8e0a5515c1ea33a84e1ae70999df930a75c344a476dbafa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxcb/libxcb1-dev_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxcb/libxcb1-dev_1.15-1_amd64.deb
     digest: 981d5049c153139995fa5d28ca1da252bbd5239a25111dc7bc28ab8c556d1b0b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_amd64.deb
     digest: 3ddced0df55f49a1a83f663c94dc99af95580104cef6bc89fed65c9da7bc5199
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_amd64.deb
     digest: fd7cb0bb0dc64c7417a6418bdf4d67145947902d5dd668eab4949811b170ee51
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/z/zeromq3/libzmq5_4.3.5-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/z/zeromq3/libzmq5_4.3.5-1_amd64.deb
     digest: 6374362f4defd2e6a454b31a8fe8e407aeb5558c4cacebc6a97a3c9d7f639e18
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_amd64.deb
     digest: 92ec406d537e08271b66dbcf10d5730fff8eee067379c9fce7e74e4c53c6b4c3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
     digest: f7102c09d7ca6cf19598b0901a46799ed935bd3278323121b11360f38dc48c9f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/lsb/lsb-base_11.6_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/lsb/lsb-base_11.6_all.deb
     digest: f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_amd64.deb
     digest: d184d5fd7e340055beee8115e1f28663e539c024ede10773ac03f4ca3f86e343
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb
     digest: fc03b0233080c11aadc3ef81283bcba5ff4904e0591ecf2beda7a4e7157e9975
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
     digest: 848333f2b40b586ecf8f0db2b6127398d0423867e689937c4427ab15570e5581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
     digest: 729d9b051d2dcda0d0bf51fee21d3b685093314a0b2283926f1eb11f937cb04c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/patch/patch_2.8-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/patch/patch_2.8-2_amd64.deb
     digest: a68c27b1c86624c5b6b60668fe0c11f4414134508fd97454a429e4b7211f70fe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_amd64.deb
     digest: fbbe40d23fd9d76c088b9470785cf11bfc4929853f35a3633cace4c056b4bee3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pkgconf/pkgconf_2.5.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pkgconf/pkgconf_2.5.1-4_amd64.deb
     digest: 87f2a519a3a380c8b37a7893aa946982ec1fdd44c5da65de8ea1451f3254a7c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
     digest: 4b0fffc886401daa9acfb53e2b190528e3fad37a49b989c4fae6715004fda41e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
     digest: 3f6d07590c1e8957fdc76082f19363f1fa8e5fcf94f7ae1bada4afbab55eb92b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_amd64.deb
     digest: d175f018dbbae1236092a09cceeb89b8686be4a1acdfecbe1b43f30382f97928
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 3650095cac77b7bc99f11c237f73c55261a58be84049debe73d180177b8c13c2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 642ae2df2fb1d602328b3120a2a1994a44bc287b425871d57d48327171013124
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 3f0cd33c4f11641a059918ad007794caf8b8e0476b9ec0ef338973e51be2e26f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 4188bc7f888b8af599c9ba86b2dde2deac914ada44a4d0642643cb5e095f594d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin11_amd64.deb
     digest: d1dd97852b32905722f0e502b9ebca33076850baa978ed48b6630ff7799831b6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 6bc99ad428297c0e00769f564d98aa47f2c03a4c613e5b2ee38ff7e1d0520025
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin11_amd64.deb
     digest: b179589ab0123be97fd96c0a132aafd28dbebf3115bbac4a3e52cf2d58b34db8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 6dc568b3b94ddfde4306eba456c4b1de680547c49c8f553bde61528a4cec0259
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 982d93159b83c957db897dc6510cd4b49f7ba1f3a1605b57891f0e4b1f92e716
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 8250ac99d0292cf182a88e694ae79da94b90252487c622c0e69dd6a0122dd5bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_amd64.deb
     digest: e3ab20d4d1cf4ee712ac3e5624e78369d8cb5bdae57f830111ca244abbe9b4fb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 4ec906d0b86f6ee416a0f7d989fa994bf29dc109fc2666ae5a109584a767cf89
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_amd64.deb
     digest: 3c7e5c7b9970e4d65a36a8480be3572faf88247c25e6885c46232042fb131cbf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_amd64.deb
     digest: f97ace68363e7bacbb9ccbea0e581efc04fa2bbca15a0f520e8ee2fe84ddea53
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 9c663e6e7c4a2492a3313e19e311ca5d7579b03cf3411ed0a821400424fe8e3d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 0cbcbaffa069e368c784bd539dae929c71183fc2cbd3fafc1d276442ece2f0c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 8f10466a03ec139a920c6bb7544a2bcdf9cd7e2370012592ea6cd84079a2f1f3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 06d5a43c2ab84ff3a763e005362c105738d5284aa59346a275718161568aac22
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.43_amd64.deb
-    digest: 850909e9459628fdfa4daa79d394e7eedd999eb68834f555000ddf17a551b365
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.44_amd64.deb
+    digest: 61e1b97af9efd245f1b4e37995bc45f6f9df0780ebe565f2226550813d29fbd2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 054403819848ca761587f77e239787a33f3ab894f5c6123176e633228503e79f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin11_amd64.deb
     digest: c350bbef6907ddcc08b22cbf73e5b03e8dfa245c3e3a31269e44020e479cd7a3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin11_amd64.deb
     digest: fdc3d77c6eb4c0eaeedfbadbb219b8ec3938e1bc65d3a4826218abd6379f9db6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 5732c11fa805290bccf0f9ac2e8559051a49d6b720a2399b5d2296e305571e9d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin11_amd64.deb
     digest: aeaa6ab4227e0c4d6ef260f17603d97a753c23fde053162f3c04ad87b82aa94e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 685d78ad540501680143b595c317c89572482b803602019d9c11d0903b857dba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin11_amd64.deb
     digest: af5bd555af5790eaf027ace9ebea6bf39360ee7cb4d15d29a7af09f45f74472e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 6e61d9ca9df23b7d37e20b38c6cf8d6f29802d2aa44207ea04d7177ecad301e3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 2e5b49e0df262e694f9cba4025de5f553ff949694576b33d9691e32bf97a6768
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 828779a51bed08c1e512fde3780573bcb170c27eb52a8128144eca8b5a108762
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 5320e2ecc73d82da7b559b8d14d40b3dee1f5169442e966fa5a26417b4d73a31
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_amd64.deb
     digest: 172fd1eead6e3bff1e2c19e5b6a42a6979ccb7600b2d7ac2a81cf404a1c351b1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 1f2a3cf8df720629f23dd82f581cc96abceea3edc1599e586cffe21808e721a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 2b30c0354c6653cc6cac2402d006cfaa65d0a8d5e29dd5e5532bd46d3f7a7e7a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_amd64.deb
     digest: 470f392ceedbbb90b4f889aff6987106e864db604833e0fa3bddd61baa93f3ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin9_amd64.deb
     digest: 84c8580bc0e796926a3b1b0e1003ae4504844ac201ad217ae08862258429a833
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin9_amd64.deb
     digest: 380708603878ef7b47588c5ac1774466a52d7c614bed6818e20daae1c34c3aad
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 1e0df601de27fee10c046bd5b497a723639176dd2a0d225531480e9ca418c576
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_amd64.deb
     digest: a61f1a75f31b6b3ea46551a2801de97d83282870c57ca69f7d916ecac63489ea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 557a063f8555b0c5f19f3f5857a1252ef798e3ef900a651c2eef9dc1c255bc78
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 5638a78999262aa08fb911ecfe8d72d82f0daee801624ebf16c5abd70bfc6f90
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 1a30d7387e949a9e2c72e14fdce4379d0ff8d1afedb22132d3f4a921b2d20754
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 6f47aaf3b175e8dcd28d9b16325287278f3218f688aa3de38499ad3c49732b18
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 044efe5f29c58b13fe15e1e2018f8412d1a5f37c40679d1e51a2401899e4498b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 6fd46795b047a6b61f21e98c9c20992deee2f2c3c02ffe600a56b75d1219dd65
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
     digest: 9e89f44e0c10a9e499487387a568a1690e46d77078969070fc0e1368a49180c6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 861b548892972e2b92998fc2ef7c1f24ee950c7394408674348a735a79023f5c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_amd64.deb
     digest: 9673c22b10da7c5895a4d3697b970bc2e5217fe09a468eb79760bb5e03c62959
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
     digest: 9bb6be934533f5c98bb8f7b1f960741a2897824cf504ea93f80b9fc2b102fc34
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_amd64.deb
     digest: e49d551b49772f35ea9a4c524e58b523dea5c665b6ad96383da54a4ee9c7058d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin11_amd64.deb
     digest: a89710c6be57f6df9dbe980c6992423d17a0ada4b4d76006794a9a3b969d8d11
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin11_amd64.deb
     digest: 2108c70067d7ed9262f6de1a73213b064eeebd6cae6e0f61741cddf17f572459
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_amd64.deb
     digest: 3fa6c61d5929042d57cc8c68816ed94701f1f995f5a11d961835c18526bd64cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_amd64.deb
     digest: 2405851738c3c42a35667a20efebc0830238f8e1cff38775dfa28edce61981cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_amd64.deb
     digest: 2469decd9f0021993e7c4f3df79c7eaef7257cdb9a99ce1f208a57446dcaed0c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_amd64.deb
     digest: dcf8a050f6f90c36f7c5a1291d6d6b6a83b2c80105f63352badb3be8dabd0ac4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_amd64.deb
     digest: a7d85abe1b4820339aa2c78c9eccedf1033b054a1b4d9899bd0887307672f14c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_amd64.deb
     digest: a28b2577b7ac8f577cd119c45df8326f88c9a5a4408c6d239038fe53e1dca3e1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_amd64.deb
     digest: bd393b38678a73c27c0d501fa9fb8014a65719760cb04a3acd813c0fd4d6ed5e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_amd64.deb
     digest: e05c22f70ce1370504ba6f537748e799a20da4170718199080beacc63071fbd4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_amd64.deb
     digest: 54037eb0f4e26bde01e38ce19d70514de69419b93d1fa5879502aca6a9eb0838
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
     digest: dbfa88dae0e66fa60e6558fa80242bb78be8dec5b37ea449f85826b1b48cf25c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin9_amd64.deb
     digest: 4b48e5acfc000ca1036accd137c30664053be4e4d0463d9701c7faade332086e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin9_amd64.deb
     digest: 95583adefac8c0bf36c679e1b32da93e2085ae60bdff0190eeccb137c52b7618
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin9_amd64.deb
     digest: a67efdf9e61737a187826d0cec236e992a65075acc43b721705a2bc743de3ba7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin9_amd64.deb
     digest: 48345dd84d7a5e0fa9dc479c7adbaf08c97be5d29b967e20b2a2ec8e69145b8f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
     digest: e70bbe5b35aa1009f8d3e8d58634052977864bad1d854230add6758ef238b1bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_amd64.deb
     digest: d9813a73176fa51ea5341b97cee8ae674c106b422737ebb819107e66068aa25b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
     digest: aae8ac2b6d3198d297d430cdb97e556365be2ff46d06525008ce071d97ac69c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/uos-license-content/uos-license-content_2.0.7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/uos-license-content/uos-license-content_2.0.7_amd64.deb
     digest: 82a4358051e045ed31367923fc6c3893aaceb6dfa9404d2a1c37f96f9de8db5e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_amd64.deb
     digest: 39bec55d10b291bf738e114dc66bf265f071c7e8cc0946a1b3319b34aed7010a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
     digest: 6d5bf0445a25257bc75a612224498ecddda2fa56edc8d17af5c4bdd2713edd4b

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 25.2.2.8
+  version: 25.2.2.9
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -13,7 +13,7 @@ build: |
   bash -e build.bash
 
 sources:
-  # linglong:gen_deb_source sources loong64 http://10.20.64.92:8080/crimson_runtime/stable_20260617 stable main
+  # linglong:gen_deb_source sources loong64 http://10.20.64.92:8080/crimson_runtime/stable_20260623 stable main
   # source package qt6-base
   # linglong:gen_deb_source install libqt6concurrent6
   # linglong:gen_deb_source install libqt6core6
@@ -179,827 +179,827 @@ sources:
   # source package uos-license-content
   # linglong:gen_deb_source install uos-license-content
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_loong64.deb
     digest: eb1f44a7f8d9c71c545fe6dbbf2b58675c2e5f18dfd14733941a2644b8908c37
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/b/binutils/binutils-loongarch64-linux-gnu_2.41-6deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/b/binutils/binutils-loongarch64-linux-gnu_2.41-6deepin11_loong64.deb
     digest: 35a35af6bf074079766e3210a42ca8fbb88e067fd8dcf48d55165e5ebad7b27c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dbus-broker/dbus-broker_29-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dbus-broker/dbus-broker_29-3_loong64.deb
     digest: c32fa99bec894b1be78e1a8a8c5ac0206a3962b750aa9338387297e240b9db71
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt5integration/dde-qt6integration_6.7.43_loong64.deb
-    digest: b8ee98da57bf17894d54683789d5165e54e7f68b5d7308593d5a390d2f5ed5f2
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt5integration/dde-qt6integration_6.7.44_loong64.deb
+    digest: 4a235801fba53673777e24af5f5a0f61158339599a0feb6ed2abf2dc8ed6ff19
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.43_loong64.deb
-    digest: 8db3962ab859d863088019c1bad5423035a72d8047206dda5dbdb98a0b4e2024
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.44_loong64.deb
+    digest: e56b5414bad1e41371025b72ae7d50520eb7452d9917da687b5d37b931a7eb43
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_loong64.deb
     digest: 60d20d41533b1a178f135352f161a1195e8dc2e105a3c0a4bf063aee66054f6e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
     digest: 377acca7fcea64458b6d0ccbbdf8773e6a23d0219739747d6a2255c6fc43cfeb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
     digest: ad27e359a1fe3485255ce3c17eab99ae42ce1aa03acd67e45a2751710dc463c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.43_loong64.deb
-    digest: 8f4a58d88b4b33a1492ef9192ed4f5c1b22f92b0e15731b7c4cd7a8c8872c630
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.44_loong64.deb
+    digest: f62529953239438e48136a67e348a9dfcaa403e836d5530ee0a1e388292b8246
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.8-2deepin3+rb1_loong64.deb
-    digest: 6f6d366a88a14dcaaafa391359ac6d1383e48ea77e43501c499f331e851c7ac3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.9-1_loong64.deb
+    digest: 06edb15fdb1076b5a66828a827b370fc9fab88b206ecde6a4379fe7dca31e1e0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
     digest: fafd08c872d1279aa0bde2e0bdf40a57721961934c0593352b6a2c551aa232a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
     digest: ef932bad267f9d4d49c0c376ae1d0fc1a9b595054f8450d42b2a0d6621bc7084
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_loong64.deb
     digest: d9ff018530bb844cab04fbe9893d87fe41d919c09d82bce9886b8baa00fde8c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/gcc-13/libatomic1_13.2.0-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/gcc-13/libatomic1_13.2.0-3deepin4_loong64.deb
     digest: 1ed85dc548b54f63267a5fb8c81b8d90638df81de8bcca7448e087f994b31bc5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin9_loong64.deb
     digest: 4e7103f8451a523b227e8e6aeec12fabb4fb8ef9770bd85f7dc14fab956a0ae9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
     digest: 43c9bedf808d5c2b85351f73dab25e81c5674c499c293be875ac5250c4b8cca0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_loong64.deb
     digest: 22511a7128c7958f774c9eaed060f2976f9a521ce4719217e74714d9c550823e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_loong64.deb
     digest: b28910a92aece870792abb3b969c20947e0a9dfeed0957b8207c49ef97766b8e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/b/brotli/libbrotli-dev_1.1.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/b/brotli/libbrotli-dev_1.1.0-2_loong64.deb
     digest: c2388059363813c7ad5e42d91f514b1e93e3dd07432634eca0a6814e2d7edc10
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_loong64.deb
     digest: b073876e60d9f9ba41ff9f984d0895c37684272da7ea5389b2ceb85598e3154a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/capstone/libcapstone5_5.0.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/capstone/libcapstone5_5.0.3-1_loong64.deb
     digest: 9fc4dad13f7d8cd45e037e5f4bbc7aaf446e76cb583ef9fcab6c5618c4e5d6c9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_loong64.deb
     digest: 23c1612c4842c5ea3315b25e15d859301a5f925f439fc377b3b989d1473d142c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_loong64.deb
     digest: 970155ff2e9d993e4daf74f3c3d1189b5ba3115603bd3e458b80aee42255a9a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_loong64.deb
     digest: aa856e77c7da5ff138243d38928291ccd9b6fd041baed5e79c50673a8631389c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_loong64.deb
     digest: eb5d0443db82c2a855562de7ef2fe8131b8b26ecaf3d1e13eee0e8bf63610f50
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_loong64.deb
     digest: 27d287c3a96cc2b0455d48cc1a68ea4f25bb9767600f5121c3c5c877b2970d1b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_loong64.deb
     digest: 617ad9b75c6b39d49d8079abaa28dd7240c53e06070097032d55c41d8e60381b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_loong64.deb
     digest: 9ca0af4b398c531c686f9751478ce94d2f683850862adc4c9e5c0c1314d42e0e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
     digest: 1cb1deef108f4163f884f564e9fcfd429adc315e9509c30ff3bcf936824ac543
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
     digest: 5ac1e65112a190dfca99abf002e3e3f0ee033919b7b65cef5e3637ff1821cc9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcore/libdtk6core-bin_6.7.43_loong64.deb
-    digest: f23592dc9270323cbc5447f476907047da92a0db8c011ede34c2a557e5f9b6fe
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcore/libdtk6core-bin_6.7.44_loong64.deb
+    digest: d6be52cbca99910b217f9a2b97a46f6f9ab7d432a9d52edf076f905529eae03e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcore/libdtk6core-dev_6.7.43_loong64.deb
-    digest: f9ab7dd52f7638c2699cd179ff605deda487c01b44523aed9dd7c968fbe8da3f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcore/libdtk6core-dev_6.7.44_loong64.deb
+    digest: 33bcc9f974a4126321dce076fdf62071179e92e708d03ffc28d45537e4008e0d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcore/libdtk6core_6.7.43_loong64.deb
-    digest: 1d0dae1fbc92ecab4340ab1e97025263b14e7cbf2941c1fedfddb64f2fd20acd
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcore/libdtk6core_6.7.44_loong64.deb
+    digest: 69bb836ad8025f921562fe49afe7db675312a9851753b79a75545897dfd35a33
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.43_loong64.deb
-    digest: 4a3f470c3c4ffc8c0290ddae0c162562d75b32d64bb41e1512f7291a91883f71
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.44_loong64.deb
+    digest: e62c47e4b4e47a428751c4cbf347a6db666071a2e8bb6820fd8c6097de9a2e65
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.43_loong64.deb
-    digest: 2f6bf9b6cc02a77b2028151cc7f568be262800f85a6f16e87979af66b41c5dc9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.44_loong64.deb
+    digest: 5a4e52af86f721aca1e99e98e80ddd7aceb60bf66a1b22d6aff538f1f8af6bce
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkgui/libdtk6gui-bin_6.7.43_loong64.deb
-    digest: f3a57b11f39f2df78c177dd6b39558fdfd7837de20adec71a533eeed086f3dd4
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkgui/libdtk6gui-bin_6.7.44_loong64.deb
+    digest: c586fc8b4fa825385c69c23da4ab3f5ac8257c00f02f6b4498b97fd6d514ac17
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkgui/libdtk6gui-dev_6.7.43_loong64.deb
-    digest: ebfc296d678f275c0307e99836b8baf174754021917aa50086396e7e3b93e724
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkgui/libdtk6gui-dev_6.7.44_loong64.deb
+    digest: 856239bb5912049213db3f01edc5ae77c5526e61d85922c2a14862a0e9d42869
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkgui/libdtk6gui_6.7.43_loong64.deb
-    digest: 469915a0f060653b537e0719ee072eaf8e299ab42efd350f1b5dd1f8f6d2b4c4
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkgui/libdtk6gui_6.7.44_loong64.deb
+    digest: ccabaea16c57d86430beabaefdda958efe3bb507f6acb069e4c93f25ef9036fa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtklog/libdtk6log-dev_6.7.43_loong64.deb
-    digest: 2e9dbe0c21b979b8b8c6732ae3490457ab6ead9aa35025862755826d5db25373
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtklog/libdtk6log-dev_6.7.44_loong64.deb
+    digest: 4a2d6600fc2ca963d43dbc2c9c9bc4a98f23e6ba4964bf263c8d15dfb0848969
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtklog/libdtk6log_6.7.43_loong64.deb
-    digest: 9a3b0efd19d43a5dddafa3b6ad0dfc7304eb997ecf8265081b9366bc004d876c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtklog/libdtk6log_6.7.44_loong64.deb
+    digest: 802f98c70cc40e376e9fff02692971ecaf92099e6e4c8f556ed22ae8af957dbb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.43_loong64.deb
-    digest: d065a43eb2acfbafec4c346ab43416098bae42213701776d5c93e899817aec29
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.44_loong64.deb
+    digest: a74ecb74ff77207c90c905b4c1963071051e396649253b9aacb4a5b1f7d1b459
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.43_loong64.deb
-    digest: 42d1f07b09953c790fc7db198cf11f0ff3db6956b8006b1b19a78c2e935eef17
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.44_loong64.deb
+    digest: c454dd192743148892161b96e11d453728ee1d867b6a91bc4f9c36928e91f59f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkwidget/libdtk6widget_6.7.43_loong64.deb
-    digest: e9fd946d7075aae0fecb30d0bf131e0f80c80c5168cc397555736bb06ed6beed
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkwidget/libdtk6widget_6.7.44_loong64.deb
+    digest: cbda8115e23af2a72ae5809a9a399ee60789c02e22d2f35ff2a561503afe2c2a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.43_loong64.deb
-    digest: 5f4a0a6435f6342398ba9c3d6dc5820f22c690c9b0541710fc959c08a521c265
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.44_loong64.deb
+    digest: 89cef8291a324899735ab8e1b6a5271d100a44a3b8b4b4c148fa5c10efeeea1d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcommon/libdtkdata_6.7.43_loong64.deb
-    digest: f3f60a34f94e9e6a4d861f620d0051e590bb878ed01adfc7be9ca6ba58d54344
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcommon/libdtkdata_6.7.44_loong64.deb
+    digest: 0e608c2747832e08923270375a2ff281c1d5c22028c6e93c72bcf0a9263c5ab5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_loong64.deb
     digest: 43ea506dbb0c9b69bcb06c4cb8e40151bf81952367c5355f830f87288c3fe462
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_loong64.deb
     digest: d076ff9e61c87ebbf1a4d592eff79d32d6358fa8cd1121a30baf7ef92b764a0b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/e/expat/libexpat1-dev_2.7.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/e/expat/libexpat1-dev_2.7.4-1_loong64.deb
     digest: 4e9e9a06a407d04a44dd17b7a677bbc63e5d41bb0341de881473b1fdf48dcc15
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_loong64.deb
     digest: 1247f90fa5006593b184ecd8ab58a9f3f1d9d9a38c97b67fefeb2ba0122e43f9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.8-2deepin3+rb1_all.deb
-    digest: c5323498567c4b1fd58c620d024a153dc9ed17de13291d25e41f89a214007b62
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.9-1_all.deb
+    digest: 095f6c357e994b15d51e9cf85722cbdf80f821a8ba2e5b2310fb9a40bb2529b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.8-2deepin3+rb1_loong64.deb
-    digest: 51fb3e3ec638f8df62f6962416d35e691439ef6ac73394f6712d04c3f71e882c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.9-1_loong64.deb
+    digest: 26295740466a09a3aa9d606fc5220c21aafaa044ba912584b30b802e1fc650a1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.8-2deepin3+rb1_loong64.deb
-    digest: a70c409534b6b5848f5f67047db03672713983354f4fd8d61c858cb617c9a278
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.9-1_loong64.deb
+    digest: 0fb24dcc28b7b8d985fd1829733f313ebd788d5a68c05aa8b07d43255d6eb10e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin1_loong64.deb
     digest: a0f7d5ba9a6db562acdd76947f0029787b50779b698731876b945351f7da69c1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
     digest: 864ef36cd80bc0a9fadbdafca5a5ef05ff92458f945bc1c20753d7635d8f17b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/flite/libflite1_2.2-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/flite/libflite1_2.2-6_loong64.deb
     digest: 89927d11c271631ca816010e3825c066645c90621bc386f4dea59fbcc10fa51f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_loong64.deb
     digest: 58d05c9c6162bddfa086ae65bb7f937b94ca237eac4819cc4c614e67516fac1e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_loong64.deb
     digest: b62b02488a20b998918cc11257b322dd2d2d55060b218c23e9e4771f812ad650
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_loong64.deb
     digest: 0ca5d52aeb656859340e21163000e4533fad0073b5ed6b2de5f1cbc3a254b76f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_loong64.deb
     digest: 38184fc8103e1312c59a9c5cbc22439c444433f96ed7b2484bf96b42aaad0f49
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_loong64.deb
     digest: 37a693f96d02d97be01c45d972836cbaaac0b9a5043174a04b2e2eeff251b30d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_loong64.deb
     digest: 224418db0f3e9cca518d2209f1b948a4a933c44e98e0e27986d70f0cb463762b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_loong64.deb
     digest: 4fcb65ca8a64a9917615989f155b1bfd4741a3127f1958787d8ad27b9ef8d548
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_loong64.deb
     digest: 260b85824035f054f7e25e2b142ee5397c28953f77f463276203b0e5ed8d9bde
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_loong64.deb
     digest: 03512d70fb50bc97266e9f14dd56fc5577d455aed40072f0f2794056bdd6ac28
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_loong64.deb
     digest: 0dd514b4720617d406df515fc6a95be7e19a223e3f1c40da22128b46facf7989
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libgudev/libgudev-1.0-0_238-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libgudev/libgudev-1.0-0_238-6_loong64.deb
     digest: 743a0e5aed46c4ed65bbb4a7dcc8d1671399c972a2139296b7eff8a529da1510
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_loong64.deb
     digest: e064f26b79aca0044bf1ebd77ac29d0e9470aef6f8d97cd90284389b8336fbee
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_loong64.deb
     digest: eb28d4bec657f7273f965bde361caca747436978ff2b8dfda5bb4ce292c8868c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_loong64.deb
     digest: f032e10ca2f485b3db38778d9a01d22dbd92d0aaab17f7b543d29aa4651b55dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_loong64.deb
     digest: c675f26dc073cd01c6098484e841faefea0de2e1606eaf2de5980942a90fd487
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_loong64.deb
     digest: 1cc8375ccbdfff3024272e03d8da0106288dee124510fb696ab213b02fd391f5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_loong64.deb
     digest: 0c3b4ccc6927abdfddb2d909ca139fbbf1c5e81ccfdba90c1ffcce9f460d4cb7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_loong64.deb
     digest: 152658aba54e2f163ba19c0fe53aa7666e1c6907eda79433f1ec38240a9670b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_loong64.deb
     digest: 342808c163f19bfdfdb7f36cf51acce6401aa2c0df6fd5695d0b3a9f2731bd9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_loong64.deb
     digest: c0a9c5a24ac81fd6e5641d36d47600df17b732fe3a5c024753da8e32679a1447
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_loong64.deb
     digest: 6b486a85ac27b4001d13fb43838047f46ea84c3b97baa48d0ede572ccd47817f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_loong64.deb
     digest: 3ae2965f4f532a1dfc813c0d9ba0461219093f4f0ab50c9f3ca77ba99d71cf34
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_loong64.deb
     digest: 53c2272267e61ea69f67973a7a43374ac2ae02be3adaf20f6231b7cf274a766a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_loong64.deb
     digest: ffdfa4f9a32fc2be622d68b3118ab848e7e01bc063c189ec5e5f23fa0f686a36
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/md4c/libmd4c0_0.4.8-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/md4c/libmd4c0_0.4.8-1_loong64.deb
     digest: 38b04a9c6431d337342ef954a98ddc75b6ea0da7b17d321cf5f4ba17e73d9dea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_loong64.deb
     digest: 501c91fa0ba7cc9f6bceff658ffdba2323039a590719a2030f2dd37266d296aa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_loong64.deb
     digest: f3e26945d53b26d1787b23cdbddb89afec7494f2192ffbb81d75e4ce7883aa23
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_loong64.deb
     digest: 9b74501e7c7e6f5d5708bfb897a6710f2144da4806717be60cadb34d2e180353
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mtdev/libmtdev1_1.1.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mtdev/libmtdev1_1.1.6-1_loong64.deb
     digest: 4a5019080a0454a1380d3353dbc52b5bfebd3ad8f4c210425beeef8b6e5113e8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_loong64.deb
     digest: b8ccd5bf943ded55cccdc92d59c8abb35a1fb65fc3425ebe35670d37b7bdad6f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
     digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_loong64.deb
     digest: 2edcd978231e1d513566ace5c07cc11449586130e0e9b8d5bc126d8a56f8e93f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_loong64.deb
     digest: cd4ffaeb85402fdee4cd618e5d95b20857b2eb83f25d6109f8026b714b4af470
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_loong64.deb
     digest: d5f7b919880e85ef999377610d15bc712151a6ae5b5aaf9752cc59d21923992f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pcre2/libpcre2-32-0_10.46-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pcre2/libpcre2-32-0_10.46-1_loong64.deb
     digest: 2db80a8bfa1f9619374622e0e01a9ea79ba3d2e886b0347a078889c73f969b38
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pcre2/libpcre2-dev_10.46-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pcre2/libpcre2-dev_10.46-1_loong64.deb
     digest: 6ea6b84b6b95885e921a2eb737bc9482caccfdcc42c9af8661f2de7e06c3f4ae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pcre2/libpcre2-posix3_10.46-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pcre2/libpcre2-posix3_10.46-1_loong64.deb
     digest: 58accb378abd0821d37bed2a8185059f72a05e1174c84ec5424ce3f4118188fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_loong64.deb
     digest: 9b68dc19b458a678ae21f5eec1f27f011f0c8da502cf3cf234b5cf4f8e2b093d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_loong64.deb
     digest: e91b4866403e8d84c86e77498102e47cb3726474149cf5adc51e59cafff8d5cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_loong64.deb
     digest: 64e6558bc63ff72790f04695835cb1d713a4a259c211a63f536bb2c8da23cf53
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/postgresql-16/libpq5_16.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/postgresql-16/libpq5_16.3-1_loong64.deb
     digest: 2797807f5da6690de1c2dca5caeb64d6ebe42e21a98eb07d04c5a117b7c1a6ba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
     digest: 9d68b88d2e9de4c313b75ec6ebd8df51105856bf8998470dc7faf770308ddc40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: d7e2c48549363ce6b2d199b6bd666ac75adf950e3c38adfea530b856dde6d90f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_loong64.deb
     digest: 0516b6c29f4313bb30f9cf7858cf93c4d1ffc237a967eb65b3f0d5b943d83d7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 7128ee456a1ed6374acd7e0027198e963f437d37a58c7729daac8b66bbf3e59c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: c2c022326e4bae1ff2c9158843dc63dde951352d27afd729e51093e3e8debbad
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
     digest: eb6a664507e891d69db263120e88b82bab4cfa104a39a28fe772d8beeeac21fa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
     digest: 82be98a5406a45ff7c0f16ba2015be9bbf3a269599233ac7fb25f28407b8ac07
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: ca54b35137c523f102931c385bd27ea400b567135ada770c5a44356a885a9874
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
     digest: 0c68f46baa7a14cf0ff955d04931ae6db3a6a991e4efa546eac8b0af5000e3d0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_loong64.deb
     digest: 50cfc130b9f7bbc24dc0eee4ad75bd15dff40b9f126942ec1010f6e85955e112
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_loong64.deb
     digest: 84bb00e7144d357bb9f52720eba503deadc3939f34cd4f1431d8abc6c9181194
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 61af475b7d0faffe02ce7d96b868c825dbdb30abc5b4b613d5244ed6cdee01d4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 0b541fa8b533975959f62a06c3abe11da05db8fa461aa5f1da535ff72985c173
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 66b1407f06d1f3bd44fc40e16b5a0aff4f9ae1bda6fff8740337f0692a3e55ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 53a045a00eeac608d078ec94f3c0fbaf040b4a14933659088cb550ee2f72c30a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin11_loong64.deb
     digest: ca199de10dff716f18ef311b88cb82c5a762263a7ab5ba816939d519ea958135
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 724f78f71b936a7f0919ad7e683c82ca1a9b5d2e66655c43931d282ee47a7c5d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 76a94967a1d99d03c9dbef9766ca61bcc81cdecb3b8d42e56d438cdd5d8cf354
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_loong64.deb
     digest: 9775d45a33e9a2b23cafebe7975e731d477020d65cd5044c722b6918c271abd5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_loong64.deb
     digest: c2582a775b4bcef766cb710c214e928d3acdb33584129447ddf2200956fd1325
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_loong64.deb
     digest: 990ac1a932968384f8f0bbfca0fbb20e11ad7dee53a29a5e425beb8c83cbdb7e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 8785e2c83381f3af791a1a98f722cd1b8ecb3a7413f7e2acc5e6f981bbe0329c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 4f3b075cb20dfc30980d52e9ba573506eeff09ec9c5f0b6572fd4a5b27d4ed9a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 92c1259194bf04de719e2943745a2518766652a923226bc71c0397567d6c5eac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 67519d24d79c1f0671a87bde7702bb2173f6efdbe62f113f437d2e2b0e9ac84f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 4fdeb9b9e47841780c4e2a4f2fd76b064d28185b374672e8de00d6973e0b8eb9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin11_loong64.deb
     digest: bd32ab1a9ee79384f11337c29311118da8939535c2b7188ac96c8008a20f4c2e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin11_loong64.deb
     digest: c3c5f25f65b9eedb6139102cf2712bdb13c24d4f804b997d0d25cffde87ea7dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_loong64.deb
     digest: cec7d316516b54ca0babda908001f58c1055f8af78022528d6fe3868f6f90635
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_loong64.deb
     digest: 071bc2779dd4d67d41c836c3df87c7cf10e50ad7fa5aa8600422eeb345b85607
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 67572eef71edc0c4ef59b556b49aa45629bdf7fe2e9fd98544347ccf34c1b84e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_loong64.deb
     digest: a9a4357296b903262ec36179191f2245bd153128c1ab4ce0e6a27106170b5c2c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_loong64.deb
     digest: efca3b1e94b8678c86f2a5f96e63cc2e92966cd75e58e8a152586741e432250e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 642d79f05b64f5e87c68b2b2dc608aae245dbcc9633722e22c76690ed5d3cf28
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 4c634c8654c06847e5134e5c4e9e3cfe0c18f512a70f050720d0387658bc1dcf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 2468a7671a666d247c83784a2a0bc4a5d5a30adb3e3269c88dc271d57fb6ea31
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_loong64.deb
     digest: ee578b410845fae862283b615ade90b89109255542981966270e8cb05df53d98
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_loong64.deb
     digest: 46c7fc620275a7aa02aa852bd1a47669cb5da8b0b23ef296e5f53b317738ba7a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 1f3a87afd485f8704fbe75357d769748b4733d0ddfb934c6e89e689e7344b4a1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_loong64.deb
     digest: a792f970a150d5fd7b60c3e265f8117600556b81eaa4a8834a1f65163a659e5d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
     digest: bcc5d3441b82068d621fe024b751eb6642182b5f86dc7b57de237edadf190818
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin9_loong64.deb
     digest: a2030468479218b5507a38ecb50ac94a988990891430fe8c34f5b4e590c57469
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin9_loong64.deb
     digest: 9e22d20ef0d22f5f8f498bb00fdc3d7290b1a89c5f798a25de09c1e11612101c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: ce4094716759c9c88fcb36b273986d8f0fa1328c3279757f3ab9737306b4027a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin9_loong64.deb
     digest: f8b55f6c519f163b6d1109597f7cb57b9fa990516f447e8df872ea45eeeee76b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 37a4d854d9d9c296b5092ebbea98b035a85fb5b871ca7ce2c365e98611899e2d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_loong64.deb
     digest: bfc60cbd6ee84fd4a6ee2d1002c27389d58dd451f8ec8bfde0e74fc8dbcfbbf4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libr/librist/librist4_0.2.11+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libr/librist/librist4_0.2.11+dfsg-1_loong64.deb
     digest: 2611a022edf6296d51869158a331d6af6470739d4ad74677f2fad25350d1840c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_loong64.deb
     digest: 3560dfdbcf90fef6f1fe16715e1bc7543a4e84b8759c58f71db0d93054bb7d49
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libsepol/libsepol-dev_3.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libsepol/libsepol-dev_3.5-2_loong64.deb
     digest: cd6de58ec8972c1be0f4028a31b7b94d8079bd1c0bb6af78c21ab1c1a0b245a2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_loong64.deb
     digest: 9667bac75f00cdf47520a2ec5d444bcafb4c8eb3e13efdf86218f5c69d68652b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libsodium/libsodium23_1.0.18-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libsodium/libsodium23_1.0.18-1_loong64.deb
     digest: 967fe90420e1c2608209f23f3a959adc2a3395203139559ef52a957bde15123a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
     digest: 760ec85164e31b757b0e46274b5a1eafe5a6ce53ccd0e1c4c1d7e5338e93c31e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_loong64.deb
     digest: e8619448ff773a2ab7ad66dfb6b345f899c47601e40b3982bd5b97dc701de1c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_loong64.deb
     digest: dea4a89cee5d7d70b6143ef55501595bfa963aee8777e0f1b10f46a78dc9e578
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libssh/libssh-4_0.11.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libssh/libssh-4_0.11.3-1_loong64.deb
     digest: 519a314568242027475eb9425196be7a19fad611cdccab8273cd7ac9f053de85
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
     digest: d5528cf8ef1dcf19b1b3245d894851bbddc35132ef3fd22e8c399fd5af91a514
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin9_loong64.deb
     digest: 949ed473270db480c09c1a427b74c2818ca01565c26b1eb386a810badaf46867
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
     digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tiff/libtiff-dev_4.7.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tiff/libtiff-dev_4.7.1-1deepin1_loong64.deb
     digest: bb264461c5722bcf18a18b146ac9e02670e2f9dfce43dc43b090f4d1396ce1ba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tiff/libtiffxx6_4.7.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tiff/libtiffxx6_4.7.1-1deepin1_loong64.deb
     digest: 20bcf3048fe9af47b6d7241a5f00e2cc1e5a844d1087c2cde4cda0cc2cb6e8ca
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libt/libtomcrypt/libtomcrypt1_1.18.2-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libt/libtomcrypt/libtomcrypt1_1.18.2-5_loong64.deb
     digest: 85e1e7482f2e1c928984391c424de9d81262ef9ad9535a1a5675eceb4dbe1830
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_loong64.deb
     digest: db75255d3c07f0d76e854af80a1a6090e023a5bba421ba75781bb669cf85a3ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
     digest: b2217959e0d34e5ce86a75b82acb235e1b887696044937815544c576c7abc9a7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/systemd/libudev-dev_255.2-4deepin25_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/systemd/libudev-dev_255.2-4deepin25_loong64.deb
     digest: 2ade21008fa24badf7c88fe545c96223c8cba29e252e048bd1e1856cae0c5b8b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libu/libudfread/libudfread0_1.1.2-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libu/libudfread/libudfread0_1.1.2-1_loong64.deb
     digest: 52fe8c374d5b0f18d538139bb314839f707a1ee6da3090d411fb9c2aa9c93e49
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_loong64.deb
     digest: ee8791150f1bfe803c6dc3cbbb699a5f6db83f9acea98d0d7af33db8cc50d929
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_loong64.deb
     digest: f85518b7ab894cce4194fa481c391a70ef19c368aa8bf8b755b2927ca1636a60
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwacom/libwacom-dev_1.12-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwacom/libwacom-dev_1.12-1_loong64.deb
     digest: 80b9f218239d0521b8c10264860dbf34673b210b56e82ee01ce149a997c57a0a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwacom/libwacom2_1.12-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwacom/libwacom2_1.12-1_loong64.deb
     digest: 87c13b7db15b7c19111c5af081825d48550cd48c351e3c5ddfac976939bd67b1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/w/wayland/libwayland-bin_1.23.1-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/w/wayland/libwayland-bin_1.23.1-3_loong64.deb
     digest: 82dc01f90ca12bba758c00e7591bb7423859729e15c55b9b7de7a066d82a0a53
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/w/wayland/libwayland-dev_1.23.1-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/w/wayland/libwayland-dev_1.23.1-3_loong64.deb
     digest: 74aa1a5380f582d3fa512b1e129fd02fc7adc739766f19561c369652e7024458
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebm/libwebm1_1.0.0.31-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebm/libwebm1_1.0.0.31-1_loong64.deb
     digest: e94dcc495430d1a7cbe0c2130043ef0db8037519e7d82550d5b62e9fbfe9959c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_loong64.deb
     digest: d1393a8e0ee0c5e7110a47cd729f042ac19b418bc2560f4fcb330ff1addddada
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_loong64.deb
     digest: 6d33f9002478ee47a87b1906776df767e1248a29ff07c07e03aa44980d5326ef
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libx11/libx11-dev_1.8.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libx11/libx11-dev_1.8.7-1_loong64.deb
     digest: 9ff2157ecf2cb67c552cb49d624b32ab2393991a184e5151b233288c9a71113d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxau/libxau-dev_1.0.9-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxau/libxau-dev_1.0.9-1_loong64.deb
     digest: 15f907de0f88e9aac91b9fca3c609de2330cfe0c847b91d73ed5f3e2c4d098f7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxcb/libxcb1-dev_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxcb/libxcb1-dev_1.15-1_loong64.deb
     digest: 3d4b82cd16df0487be74f8f9f79d27fd7b0c5252c2a1c7bd2e03fa6453059728
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_loong64.deb
     digest: 389ba314f478942db7167a50aa9682dfdcbd01cccd82eeac649bd9744731aa89
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_loong64.deb
     digest: ba47dce288d90726795169d45ddf9b07f57c9391776ab2a4833ac26fe01a9c90
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/liby/libyuv/libyuv0_0.0.1888.20240710-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/liby/libyuv/libyuv0_0.0.1888.20240710-3_loong64.deb
     digest: 5db04094a96e73a685b42d380eea7a3f3b84feeb02d941531246ecf45345d6fe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/z/zeromq3/libzmq5_4.3.5-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/z/zeromq3/libzmq5_4.3.5-1_loong64.deb
     digest: ea9300e3470746654e2977f1f42d4577d502625781cdf053bea7aeff012ea17b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_loong64.deb
     digest: 542cb13caf60619314815e4a117fb1e39c3540a241aa52a34fb9cc7b4717f08e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
     digest: 300cb587a7919079edbafd58ca6c5d82ec6783aff34e3f6ccb8c5f4f170c8a5d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/lsb/lsb-base_11.6_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/lsb/lsb-base_11.6_all.deb
     digest: f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_loong64.deb
     digest: a6b376c2fd149cc6cabd93cd94dea5c9793fe8e9b9773c22bb9a12812ac52cf4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/make-dfsg/make_4.4.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/make-dfsg/make_4.4.1-1_loong64.deb
     digest: 549a2844f1ba5051fd3be57714c0e2498054ebf269ecfe235e532a0b363e4f8d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
     digest: 848333f2b40b586ecf8f0db2b6127398d0423867e689937c4427ab15570e5581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
     digest: 729d9b051d2dcda0d0bf51fee21d3b685093314a0b2283926f1eb11f937cb04c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/patch/patch_2.8-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/patch/patch_2.8-2_loong64.deb
     digest: 96dd75e1b9172451e8876729a534d1f7a4a3b36476c849aec10309973c6bf44d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_loong64.deb
     digest: 5a57a719ad9fa99d70119cfdaa3dfbc94b19c96a1cd183188125395845bb5b76
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pkgconf/pkgconf_2.5.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pkgconf/pkgconf_2.5.1-4_loong64.deb
     digest: 649c5d434ae0019a221b37d0f3e28a7a4c1b94e83e54f99a2e0432f833dbaad7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
     digest: 4b0fffc886401daa9acfb53e2b190528e3fad37a49b989c4fae6715004fda41e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
     digest: 0287e6d08e13e90c9fb8672adc90fd30703e8f4911da23cf0025e7e1d6101533
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_loong64.deb
     digest: ce4d39684a0fc7bbc5c7eb4cf14b8f99562a8b08c92c98e7e0f240d862256f4a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_loong64.deb
     digest: fb6e0f4ac13b05e7a6d6a72e1c1f8688f815e7a27befa9dd3d81b9aad2064d6e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin11_loong64.deb
     digest: e1ad2d94a1717f095ffa460962ecda44c7b75423415f9217357ecc7c4eba1082
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin11_loong64.deb
     digest: d27ddff8f49e1c939be776d3575027c051df84e38c38f470379f589bc202d4b6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 27e12048ab69b6d9506f22438552de426eddc3f64e9e4bcb6c25f4c2b4b43954
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 69e0bdf6d9588fc8c65da95535dde9b524ad532564868227200459e54c6e4f99
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 6fa09645e98fe4e339d7dcab8897480a91ff19f92639d9bebb28e421a9e28c05
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin11_loong64.deb
     digest: c660bc164102bf4d36d61eb7f4537c53cc8f8e2255556c3f8e3e6c1e52950dca
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 3db7feb7701baa968031f1ee7d7753e0e555c0ce6e7273faf51172976c16f3f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 1b092bcb57751ff8bcc71c7af75bcc0f75bf4e41d8e532c11453362dda415108
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 45dcf0638ea0ea67ac02d068bb54b908659cb71b220dac0f7169e1c5facc21bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_loong64.deb
     digest: ccfaec5003e238ac01b62089ee0f4c52ba30e9ef5370c3afa17e3cf7ee6bb318
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin11_loong64.deb
     digest: a886e5d99052250ac88865877c9d2ae9bb2863f8fd90993738e264ada279a9c6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_loong64.deb
     digest: 43df515525771e1c6d23246fa728102c60a6fa6ceb37769bf3903b190b50f819
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_loong64.deb
     digest: f9530e42280535cf1f08732b4a307c112baa3820b4bd185bce1577d20eaf6aa1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin11_loong64.deb
     digest: d57c2b241915798dd215f857ef5e478d9e544321372d848459f32b87b8ef9f4e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 34f9d27dbb8607499dd9d51941eb2399dbd242ad417b94bf09d8b090815b6026
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 944469b76b2fbeced41a2a62c7be09783c0494269aa8c48cf6a97cd813be71fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 47981a121f3e63f6451f12b05a83f2965a0ef189642f494f2b91055a31302701
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.43_loong64.deb
-    digest: fcc5b9ebd08b8c92a69cc3fde29d521dc778b0e058b5a1349ed399de67b5ec6c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.44_loong64.deb
+    digest: 45d6961f93acd0b847b8654c27b91a9ed9a69a8f2f53c05cd87ec016e61b7ed2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 89220285e6ced9c9143db6a21753caab7c7ed7fe8bb1a4a9e2738366b6951f24
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 838ba98020e3d69283491480a0cf6914de962ad9ca563fa256e9b7641928bf12
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 333e720a1a0b1543b1766fc5653dbb48e6b9937f2930a57a30175e1531122a91
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 86d9a37e183a7519d39d0cf83a1a606285cda1c0f280ed503a58b6e5826d9e43
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 8a754ad07d6b66724570dc90a2353421545c43f867403737e88ca84c0b0189ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin11_loong64.deb
     digest: b17f1dc8a2dab45c21f87fe35c51d8c02c340458587c39d9da78e677b9123224
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 5041f81baeabab7b0bab0cc090ab4f3552917f7acc6be2d30d0f1d9419097442
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin11_loong64.deb
     digest: c1dd0ef8b4746603fbf714fafd662a459778fb20b3c40203b90b65746e804ba9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 51fc64212ad9899a97363231cba60ebba70f7845e2507c330d0073a94f006593
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 9ddddaeab936da42efff955dd2cab814264d69e10b2f296ff9e46611eaf0d0f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 67567d99b1cb360c5262235f3beb2a25cee2206956cda216b34c81b92cb07323
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_loong64.deb
     digest: ed0e44c516e67bda0898057181b8a1c8c75dd729fdad49961e47b0d44bc9a5f6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 6bbaf526f9e5d1d89e995907343a88f986cec61d670b5ee49612a83357ebd9ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 224a5466424babd2e9e0318b4c6a4beeb359e91bd5aae75532321b936323d012
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_loong64.deb
     digest: d3e7911d9c70e0095aff698f109dc879c5e41606bd7feb91d6eb0ae6d9e72753
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin9_loong64.deb
     digest: ee25e73ef10f4bb7ff55bf95f2d82b69c510842c3d27d2bef3f70b7a0f94f288
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin9_loong64.deb
     digest: 656bdc515088888be04a6a9ddebb5cb00a85585976c371014ed8867f75da2882
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 8607c86382ad4683b1a74d75098b858892a530f3d72f374b183ce0975b1ef2a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_loong64.deb
     digest: 663ebb93a2d4c641de8c11920366c7b697027bfd35d3e41ca65b514016234b5f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_loong64.deb
     digest: a18046026562749119024973ad4a10eb2dac2cb6cd394c96054c2e29a380eb03
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 1e4782dc0f2d7e3e34a04af8fc4035f7674567717fef03211167842ad09d9bb4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 983001e7e63072707300368401c0abf15f2d6a1d557d803bdc7c6488012f5115
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 7c9bc44803d5cf01f4635dacb762f24066e345cd42d74d44fd15e27bdfc6f07b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 9b0e724d139a969e355ea1887cc94223fcb2d4dee57edc6594d4c9de07dc10ef
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin11_loong64.deb
     digest: b3549283782bf11d23448ff8d6501f3d37db3140245ec45f44db690942cc439d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
     digest: ec3065e7d3127545cbb6dfe84c2d9f7e38b015a368033c1b8c67d955f8001b95
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 3ff56c6a9e982c44e70ae641d669cd64aa871e950cc2916812ab582f5518a8d3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_loong64.deb
     digest: 53a2079f81a2fdfbc7662bab8e901eadc88d129908f90e7ab759bcf6c4f74c29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
     digest: 91e20e6b2f68393e3b4764b9f57d55ac495174485239a607f994ef1aee08c459
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_loong64.deb
     digest: b1199d84256f297e6dd6d3b3cfe173285df461da56b10742c9dcae91c616675a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 0b272edbb22391b818dd249140ebbe5442a4ef938eeeac146012140571d224cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin11_loong64.deb
     digest: 8fc61822a0368657c7d0a794efc39166ce1c6f0df93a77a593ac9a7264cdeb5e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_loong64.deb
     digest: d34656ffcbbb09534dd7cb5c7d7a05a813b3e739f74c1a95958a2e3ac4307178
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_loong64.deb
     digest: 366fe25e1aa641f31c261a422cd578724b47e3336d43a913e24a3d0c3d18c1a2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_loong64.deb
     digest: f7d6d0e11fea53ada98657b4a547a7758ba1fa1e0aefe109b9b1605a51ce0bb1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_loong64.deb
     digest: 0b390252dfa1e2666f40d6ab8fb75535169d22b21879c19a67f9cda4efd1432c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_loong64.deb
     digest: ccc3ca5bf5149ae18468a0791515a746e4c6d4839e63547314786d7b3977ee4f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_loong64.deb
     digest: 32fa2629e5a6815dcefe7e945cd4b4ccc00712bd72cb9c79501998cb6e39a4dc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_loong64.deb
     digest: 4c27718be3d7bb75aeb12a2b6ffa4764e4600edb6b06cf3f31f45f99c70b6fcb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_loong64.deb
     digest: b41b3f13bf4aecc868c876dab50bac5adb4471ccf989ae8641a2fdc7a83878b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_loong64.deb
     digest: 46026db29c9ff37a25638150ed457ef56d8a29b5c973ba386ae44ff0ec30ba03
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
     digest: dbfa88dae0e66fa60e6558fa80242bb78be8dec5b37ea449f85826b1b48cf25c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin9_loong64.deb
     digest: 5d6415fba35f03e399da885433abf6e919453641823532d667a0613ca9dc30ee
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin9_loong64.deb
     digest: c50326b312808f7d9ac333656223263e86f1c2669d9a7c75578c8fa548aa89fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin9_loong64.deb
     digest: 3e2c026ab4afa50db7776c2e7d5302ecece1f5e11bc0fa274fe3de39fe6bd757
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin9_loong64.deb
     digest: 0e5306c16e756240822a7160b639044cbac499bae184dac051c7e2368aa5b09d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
     digest: e70bbe5b35aa1009f8d3e8d58634052977864bad1d854230add6758ef238b1bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_loong64.deb
     digest: 28127b83086c739c5c99df069d31a9c6c5f37fae878abd1d928321a6c97cb986
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
     digest: aae8ac2b6d3198d297d430cdb97e556365be2ff46d06525008ce071d97ac69c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/uos-license-content/uos-license-content_2.0.7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/uos-license-content/uos-license-content_2.0.7_loong64.deb
     digest: 75df8322b47f7dd8d65779f2c2ef1336820a2ad6af0f63d4b3e4628cb8e74d15
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_loong64.deb
     digest: c4cb5f3fab879a163726c64a88e324efd42310194291143a3c3c868fc5f05453
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
     digest: b40d74ed9b2014e3a3bcb7c6121a17e16424d0ef19c9ee1aef977b7460b1b1b6

--- a/mips64/linglong.yaml
+++ b/mips64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 25.2.2.8
+  version: 25.2.2.9
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2

--- a/riscv64/linglong.yaml
+++ b/riscv64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 25.2.2.8
+  version: 25.2.2.9
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -13,7 +13,7 @@ build: |
   bash -e build.bash
 
 sources:
-  # linglong:gen_deb_source sources riscv64 http://10.20.64.92:8080/crimson_runtime/stable_20260617 stable main
+  # linglong:gen_deb_source sources riscv64 http://10.20.64.92:8080/crimson_runtime/stable_20260623 stable main
   # source package qt6-base
   # linglong:gen_deb_source install libqt6concurrent6
   # linglong:gen_deb_source install libqt6core6
@@ -179,818 +179,818 @@ sources:
   # source package uos-license-content
   # linglong:gen_deb_source install uos-license-content
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_riscv64.deb
     digest: f1b76a14359bdebd460533f8908cfd0c2137e4a7d596c7701dc758ae6989b8bd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/b/binutils/binutils-riscv64-linux-gnu_2.41-6deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/b/binutils/binutils-riscv64-linux-gnu_2.41-6deepin11_riscv64.deb
     digest: 479bf86da7782a05c01a92e2180f1d314faac51425d2eb0480bce6ab2bb09716
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dbus-broker/dbus-broker_29-3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dbus-broker/dbus-broker_29-3_riscv64.deb
     digest: e7f386e7dfed77d33306e3008eccf0613d50081f1beec6e5a2bc02a3cc7aa83a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt5integration/dde-qt6integration_6.7.43_riscv64.deb
-    digest: 276671ebaa33dafed72d52f2a5a3bd11fff4676cad7baa7ac53b144462318cea
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt5integration/dde-qt6integration_6.7.44_riscv64.deb
+    digest: b639489a1402788782ff2941780ba52cfb4149eec33c0f14e976b9156bfdd28c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.43_riscv64.deb
-    digest: ede2454e27865e128aee5e6ecc05d42fc69bea06581259137667f293ab4dd5db
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.44_riscv64.deb
+    digest: f2ee43fdb10449a0536d723f80300b98d84cbb117eea4a2bc1903d374aa51d4d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_riscv64.deb
     digest: 2c2353029b346104c05adc2942116cfcc467876d22d28d888a1a8eb91bf2ef4d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_riscv64.deb
     digest: 95ae06220f02881737d6ec21794e03e1c930611f4eaf689b8603ea2163fb1cd7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
     digest: ad27e359a1fe3485255ce3c17eab99ae42ce1aa03acd67e45a2751710dc463c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.43_riscv64.deb
-    digest: 469d6b0429c0f5f038c12839a1f15a4439b77110ab7e3d6027d0ae86a7df5fee
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.44_riscv64.deb
+    digest: 78ba9a1acc96d866a438d3488628ba41b6354e9539f711c33e353f2c1105a069
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.8-2deepin3+rb1_riscv64.deb
-    digest: f1bf986a9da2833cb9fe262c8cf2bb2895fe56343eb92a6e2b6c934138fe73c8
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.9-1_riscv64.deb
+    digest: 00514615da4b6180c6707c624cb5b1f0ac1cbc0149560f01351767d3daa8f72f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
     digest: fafd08c872d1279aa0bde2e0bdf40a57721961934c0593352b6a2c551aa232a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
     digest: ef932bad267f9d4d49c0c376ae1d0fc1a9b595054f8450d42b2a0d6621bc7084
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_riscv64.deb
     digest: 1cec08f8cadaffb74c0e260f237c968fa1ca329bdfa681063f4c52e0c2107e43
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin9_riscv64.deb
     digest: feecee2f5d9d15b34249aaf73011daa65b86bcbca6888b83bb74878f3388a11c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libb/libb2/libb2-1_0.98.1-1.1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libb/libb2/libb2-1_0.98.1-1.1_riscv64.deb
     digest: 9b60cd9369a923a237dffba4b3c9767c9b88a84fa898352082f84e02db055a2a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_riscv64.deb
     digest: a5078ebd6c36aace2fcf1a1046a3b6385cd8fce4162de67a9fcac55880cbd372
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_riscv64.deb
     digest: e39a11eb2cd82766cd4f9162f938e313a640b9b172877be2a3c0cfa857262ec4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/b/brotli/libbrotli-dev_1.1.0-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/b/brotli/libbrotli-dev_1.1.0-2_riscv64.deb
     digest: 0039fef95d65a74e5e581c5a77167e6ea43084f9bc0dec017667bfe408869ccb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_riscv64.deb
     digest: fc087f345850b721d5a397b5bf2a0a29bf35871c8a05ab372f9a963531798f37
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/capstone/libcapstone5_5.0.3-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/capstone/libcapstone5_5.0.3-1_riscv64.deb
     digest: 524f15ff7c479cd10a82752aa838c4d89a2711da9bbab1afacd2590bc9b12337
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_riscv64.deb
     digest: a0be217eeb06edcfddf3d5384e61f151f91b3b5b7b9339dc8349a6687ede60ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_riscv64.deb
     digest: f56f75b4bad909e7170ec44927dd8553b132f442eeb40e986b3ea660b3476581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_riscv64.deb
     digest: 91a2abb2be0e0f423643536fc958ff46dea1b8fc45eb2dc54ab16db38b3f06a6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_riscv64.deb
     digest: d5fc4ccb1133cfaf401dea3d21ab85bffb4eb9a77af882934cf849183e3b03cf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_riscv64.deb
     digest: edad961bd8a8c184eb5274535d374c71ea0884bd5b6977ed8102bf26bc010374
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_riscv64.deb
     digest: b7170b1debf169971267e294a69c056bd03a312e4bba4d14608f2707cde4e6ba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_riscv64.deb
     digest: 965346a9a625404560bc6c4811eb8c16e7fbec47e762e5ddc921dcfa9072ff00
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_riscv64.deb
     digest: 0a841743761adea5fb895e78f6976412cb2db4a14cd272b993d22f3a1b5779ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
     digest: 5ac1e65112a190dfca99abf002e3e3f0ee033919b7b65cef5e3637ff1821cc9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcore/libdtk6core-bin_6.7.43_riscv64.deb
-    digest: 864deea21a224e5e87d11224d5b92af8752a5d409b46fdb8d60d1cf56cd3eb15
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcore/libdtk6core-bin_6.7.44_riscv64.deb
+    digest: e945cba8dda6bc52c367f152a54a84ae164ea9ddc768201d3a3c602fa838d8c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcore/libdtk6core-dev_6.7.43_riscv64.deb
-    digest: 61cedc01f5d6c6ede46e1a4f15a476e044b1aca87e0d91ff607f86d02f83f9a7
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcore/libdtk6core-dev_6.7.44_riscv64.deb
+    digest: 9cb738f3c169c916faafd1ea06edf3a641a1ef9edc6bc82ffad44187b48fadab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcore/libdtk6core_6.7.43_riscv64.deb
-    digest: 348c451ac8302ca92fa528e0124bba170f1d18d07839562ea5a4d724d3d033c9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcore/libdtk6core_6.7.44_riscv64.deb
+    digest: dde39acc78c064829563b6c38f5b0c4c7fbf22190e640c9c0c7f9b21457c15cb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.43_riscv64.deb
-    digest: 5ecf5fcd7295c0c02d2b2bfd84448279a49c1f380d840e6d9197dc0cbff0281a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.44_riscv64.deb
+    digest: a2b1bf9f0e8fe46c8681ad603abbdcda801f562be98b0598ba6b59ddd34f1da4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.43_riscv64.deb
-    digest: 0170de9c2a01a5be0a998493fa15418757248f115aa7c5bfba7893292c923628
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.44_riscv64.deb
+    digest: 26e05c7534826ffb072054381adbe5cc67a8b15d0a7ce42e269425bdfe57aff0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkgui/libdtk6gui-bin_6.7.43_riscv64.deb
-    digest: 22d69bc9340d75ad99962ff2ea7ef181f44b2262e9df6bf7781be909ab667b8c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkgui/libdtk6gui-bin_6.7.44_riscv64.deb
+    digest: 9531f3b53dd70879121f30a0778334e4066ce1844e763f13c36d528358df67a3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkgui/libdtk6gui-dev_6.7.43_riscv64.deb
-    digest: 3b9e9abfcb549cb6e476ef99cb085503f25f37179764bd462667af0a2594895f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkgui/libdtk6gui-dev_6.7.44_riscv64.deb
+    digest: d01280e091f569161ff00999e538c6134569ce7bd6cc1dfb4aa7cab8e4ac1865
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkgui/libdtk6gui_6.7.43_riscv64.deb
-    digest: 629821f81c1b6edeff2652af409cb02e565d484b3112cb2fb39409ad4910b663
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkgui/libdtk6gui_6.7.44_riscv64.deb
+    digest: 5bdeece84e28307673798afb53048890a971db5ddb2969337f91b4c96ddb32a4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtklog/libdtk6log-dev_6.7.43_riscv64.deb
-    digest: 2d96e0f83fa8770297dbdca2c47637dbc27d77f54a004514f39d5fb9c761326a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtklog/libdtk6log-dev_6.7.44_riscv64.deb
+    digest: fae47f921162e2b0ff407d1659ea3e04c92e99d45ca4690b57cfd96876597d9f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtklog/libdtk6log_6.7.43_riscv64.deb
-    digest: 0f68b89c42373f1f54735e8e2cd52a8c884d8486af6351109addeeaeb585b8d2
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtklog/libdtk6log_6.7.44_riscv64.deb
+    digest: e213e3c699d925bfbd4dfaf413e25ada5f6f22c711dcc37f078a311566ff3f72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.43_riscv64.deb
-    digest: cfc298d5b98c72e02cf761bac64d6db01d49b42986a0cb4436317eb54672e039
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.44_riscv64.deb
+    digest: b2d3bbaeb53ee118dcf4858ed87625222a5f304293880287b03ccfdd9b6df3cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.43_riscv64.deb
-    digest: fcf0d8d9f428e6af021af3ebe6b2f7c798a9382f9082e134b4d55a53d0cd743f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.44_riscv64.deb
+    digest: ad8fc29d609a608151fce07df66e8fff48a6224fa96dc9dc46f7e3fbdc14a97c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkwidget/libdtk6widget_6.7.43_riscv64.deb
-    digest: bb38f53803df5e1879405b95c7c061697fb8a1f32f52b8b3f54c208e80a5e6d9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkwidget/libdtk6widget_6.7.44_riscv64.deb
+    digest: a24aa0d9094519914cc9cb35de43ab8b4853b275c1532ec5317e184878646cd4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.43_riscv64.deb
-    digest: 952271281f29cbedf059063ffdb0d90c612f160b39fc67721c37075cc9cbf345
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.44_riscv64.deb
+    digest: 0059180e37e54f2693abca985808eb8b014c663bda3865831695c562ffc46d94
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkcommon/libdtkdata_6.7.43_riscv64.deb
-    digest: b6568998f5d9372d07a8614dee097ca88b2f4708445705caa91e37a8934658e7
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkcommon/libdtkdata_6.7.44_riscv64.deb
+    digest: d8436bc2713436c0fa906f79c4126bf59ef4a5020957facf478c80849963cfe9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_riscv64.deb
     digest: 61bae1d6340bcc10ce08f084937caee62c342902720aae7b921cf9a6130de780
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_riscv64.deb
     digest: 469af5334d45efc0a186ecce22d907c78e813ccfa6fd9a103f96a6054a8b2d70
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/e/expat/libexpat1-dev_2.7.4-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/e/expat/libexpat1-dev_2.7.4-1_riscv64.deb
     digest: 4ddc3ae72bc2e5f2e19df86047e7a29e9bdb51c79f32c56e3e4f322429b08b80
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_riscv64.deb
     digest: 6aea8991fecc5f08335f1db6a4f64c8a417f3fc10d4ab20f593f408c5e4fc1d7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.8-2deepin3+rb1_all.deb
-    digest: c5323498567c4b1fd58c620d024a153dc9ed17de13291d25e41f89a214007b62
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.9-1_all.deb
+    digest: 095f6c357e994b15d51e9cf85722cbdf80f821a8ba2e5b2310fb9a40bb2529b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.8-2deepin3+rb1_riscv64.deb
-    digest: 9d1d71f8a37013169d71401b7eb591f5baa0e4423150a7660ba564446fe2487f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.9-1_riscv64.deb
+    digest: 301f9d9e66fd35677fff694318fc7c326f4ee49597171dcf4f42cf380d3ef722
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.8-2deepin3+rb1_riscv64.deb
-    digest: 054703b9eb528e4d49823d91418dffaa6d0dd045ea5fcd9a5b2f6c6bc06e14ed
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.9-1_riscv64.deb
+    digest: 1f4648c7c2913b20070e2e5a383ae0185863d16a9761844a970b8d57753126d4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin1_riscv64.deb
     digest: bd1bd300c7d66f1deff7b28071e37d2df5928e0bf567334c698a37323a7dfc52
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libf/libffi/libffi-dev_3.4.6-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libf/libffi/libffi-dev_3.4.6-1_riscv64.deb
     digest: 2ea6331695ab1f0ad252a1c73350a41b1bf2d7539d26d8fb76eddbbb90d73007
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/flite/libflite1_2.2-7_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/flite/libflite1_2.2-7_riscv64.deb
     digest: b18834cae56b5af7f78fd8315c8632f87b5e947ca66eb02c008820463911bf95
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_riscv64.deb
     digest: 6d0d5c4301dc43c2d6f688370fd07d7e0aa1f04969fce0328014e1e8f14a8ab4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_riscv64.deb
     digest: 3e58a7e601e06a907f752eed448fc16440fce4352e9181b49a88d0af648e8934
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_riscv64.deb
     digest: bcc3c9bfedc0fb5f0df2becc6ef03ca81c62347a6bffb254e79df0ab0e3c60c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_riscv64.deb
     digest: 4593b7d771255ea0808390723ae350b20a711423207bcf3ac12c5baae9859c4e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_riscv64.deb
     digest: 3d289417019ad68240a262ced9658772f5198b3b4454054f77297a01cbd87400
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_riscv64.deb
     digest: b48a1513d581e26596168908875366aa9a3584385f88cf42cc54044d126e40cc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_riscv64.deb
     digest: a154c188f6dce87b66ccd625a03124f0fb58af27a79cf6781d51d652bb781fb8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_riscv64.deb
     digest: 104c18d67f0f4e04452473b93619c3849a32902f2a9e18b41e0589031ef57494
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_riscv64.deb
     digest: 1301a6b03cfb9b2efd7fb39624c2d5449e1753ac8a4382317365cc8556f86c32
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_riscv64.deb
     digest: cdc83f9ab8b3227cbca9b4b1ca4768cc161409e7561bfe581c7959c11436486a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libgudev/libgudev-1.0-0_238-6_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libgudev/libgudev-1.0-0_238-6_riscv64.deb
     digest: 3389f32ffe956e09ffaf206cf84e75057f040c8288cfe5ad2d5ccba6d9710600
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_riscv64.deb
     digest: 1db717bbca670d9f5140f969fc7d9f66a1e6c61b1c01fd8e7c5b75e093352cd2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_riscv64.deb
     digest: cbbbb704783dd2b93f31e9307db80671803cd1581018558255e9b78b1d7b99ca
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_riscv64.deb
     digest: 1cb29ca790611550ef26e00fce2f9dd0c33c23930832bc10e4661600910e820d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_riscv64.deb
     digest: e3e702fea1ff6ebb23f5645e4d2cd984dcce8e0207c09ea2ece06d3236ebe205
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_riscv64.deb
     digest: 4b87cd278c182c5995d396455260939f8766422eb989b7819388d0e7917261b4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_riscv64.deb
     digest: 7ebac4161b24d7bb2db004047bed847bac5fd6191e854ebd64349734d92543fb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_riscv64.deb
     digest: 490f6f16b226a94447b2da2a2d289d57a89fa06d21aab6b49f80505abe2f5902
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_riscv64.deb
     digest: 57d3d5bc426b2f9ab046f0fbe7f385a6f54153021d7e2a8f3bdcd27c5abc7723
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_riscv64.deb
     digest: 4c6661cedcd1cdd6a285b48761b97e4c22970c1a0a1daf00faa8a61a117e823f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_riscv64.deb
     digest: 2553dd1c07771adcbd55bbd87bd6142ca3f7266f65b5107a40676cd1f715207f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_riscv64.deb
     digest: 209f73ebc494ce3fd0809c406b75a3e65e563e35f2619be5835be522fa866963
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_riscv64.deb
     digest: 7a99cef667bcc641ff456334287c46753be3a05839a82ac3e2ef6da1fb514a7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_riscv64.deb
     digest: fb68c843d5dcd1bef05cb7b6f2e7398972f789826cf98e0f4aa229576d0fcb8b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/md4c/libmd4c0_0.4.8-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/md4c/libmd4c0_0.4.8-1_riscv64.deb
     digest: f3af7c8797caceeb57072524fb06b52f23fd3b2954f8f1e8d72f04f40d7627e1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_riscv64.deb
     digest: c99c7c1164619af8b2138b1d68fa481edb04728397868e78b527a443d9401b88
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_riscv64.deb
     digest: f99105e98142dd5e91e338c3538bb424d9173fd3443aeffe73b7096678b39350
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_riscv64.deb
     digest: 0accda97e1ccc619723c9eadbaf5b7a5a443b46b203649cba6071c57385bbdb5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mtdev/libmtdev1_1.1.6-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mtdev/libmtdev1_1.1.6-1_riscv64.deb
     digest: baedacaa7999a3ba817b97ce117b09048f68ae40238e1b0fd343681640ed82da
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_riscv64.deb
     digest: 61a1368c73406a2125c88edbf972ec08f77700e52351f22ec72a8e640513078a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
     digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_riscv64.deb
     digest: d8638306155067a6d66feb139f45d6fca7cd03dc8dc27a00321c43fab48550df
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_riscv64.deb
     digest: 7291074795517ad3711ce1a2691b68b803e84c4452f28b6e109c4818baa78a86
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_riscv64.deb
     digest: ab0a9e08eacdfb316182c7db7fadc82e2e9cadf45a203aa61475ca4564ec660e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pcre2/libpcre2-32-0_10.46-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pcre2/libpcre2-32-0_10.46-1_riscv64.deb
     digest: 48d3ef610b214672acdc40b609ab5fe459f68c45d0f9fe985f8c24b9aaa4bc76
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pcre2/libpcre2-dev_10.46-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pcre2/libpcre2-dev_10.46-1_riscv64.deb
     digest: d9083777540d4eb86a436060f100e4138f54ed940ad9ae6c49b7897eef3a6a60
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pcre2/libpcre2-posix3_10.46-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pcre2/libpcre2-posix3_10.46-1_riscv64.deb
     digest: 40f61af8aa4087e05d41ce1224d9ce011a424eea13ef32a646365230b14f646e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_riscv64.deb
     digest: 2a272b6869476a9dd48df8986ecd3d9cf745ff08ef4a48f99ba0ae91460ebbb2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_riscv64.deb
     digest: 409554b8b3589b8431f12e167d3961610797d15e7e52ad24ec8c75b9d9f01984
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_riscv64.deb
     digest: be96c321bd1781aa566d6f97f1f0cca1421f059a38fda6f0250733d9b0bc360e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/postgresql-16/libpq5_16.3-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/postgresql-16/libpq5_16.3-1_riscv64.deb
     digest: b3c0061a1e767a271b1a9bd723a73d1b0193ccd3a5216992afafe3d5ebcbd199
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_riscv64.deb
     digest: 634a64854472f76ca29c54914c400f911fd200b7b1cbca0522acccdccf697b7e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 63ea815b65dcb1ddb3268960efd55f237dd81170f56230a0f28d3acad9f43d3c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_riscv64.deb
     digest: 44d8c97b5926aa78d03b46f126e3a506b28e1c30324773455e40d3bf0791812c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 41f5b3496be7739d73907c3cf4a4370fed8ff56d179e22334fa4040e6c812bc9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 2c545cc07fc56f619ac54a5711edb574aacc88e044ed215f08d3329072cf6e27
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_riscv64.deb
     digest: 8f8983f0776b0e71d752807fa75e2cdf8bd97db8997fee1a292c4c125dbb62ff
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_riscv64.deb
     digest: 94f87d57050a627e6cc3924b5a4f13d2e583ea77dc4448c34c2a717256210117
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 5d285ab84917e50ee84eaa64c7338a18d668f4b8a085a18f48453e8928a8c911
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_riscv64.deb
     digest: 65120dc4c2a84c78386021c608b79d808217f9f483e5ab558b738c249509b8d5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_riscv64.deb
     digest: 81b863f00f1c94f38308e05213b5d266fcf1107df8fe0a7b1238ae1a266e835b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_riscv64.deb
     digest: f4c1a2908bb7f965f9d2cce6852e0193b35d1dd90748986dfe839277886db7b2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 9d38407ed490700533accd2fc9baae27a5a960d5714d9345c017d3746bf04e94
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: f7c904a7949c74eb7283b2d00f08998d452b0570c171499ed315a3d838710741
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 92c0ab7a6aa2378f80ec3bffeea58a52fd0e984df72e1ca469df8ce44237544b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: baf3b907bfba42fc6c4753cc88525a4adc52322af113fbf985b373b6bdd41398
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: d88f95abaf203ec118aad9ef04f7099c6500fff6c62d46477aa762740db4a1ff
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 63f069bd218d71bc02a3a0869ee998b70c82bc331601cc9d09c6630abc54d6fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: ed9021eb7790b0c8186ad2125320ecfe09300c9107451a8fb788232a1c317bdf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_riscv64.deb
     digest: 23096cd068f90f75d30d2dffb998255fce9a6116f8e73084a6792aa718ad1e0f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_riscv64.deb
     digest: c3db46d63b3f455ec002f19866994f555af939f6b5cd9037a1647ef8aa174fae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_riscv64.deb
     digest: e8d6ca3ec477a529a9702f43491d5ee69d6505af41120e63e57690909d8dd89d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: ad05719203df77e2b1300d5ddb79e9fe306ff07b5824dd24d5a81981bfa3eac2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 80fcce954b972fd72cf7210d42356479823d2e57ec9dee8a2a35f351adc77ab2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 5299c488bf3ed4933ca40790e28c77fe31c842f3a03f54683778c70ad6e3eb8b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 4b79c8df3ed8f851a9551f8b5cf47f31876169472be28d1cb7f1577f39675956
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: a9ed94a680900cd01942aea43c0ac73e49a76f61dc8fbd241d2e7d47e418f96c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: c9a0452fd493eb329d3709db8bd14c3b24f3971391f75242caad4e8948ed1259
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: df369a80444a96888a199e8ad7221663cfb81cc05ad71f85d5920b32703e47c3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_riscv64.deb
     digest: 2ea67ea515a5ccbe57225f97b66a8c349d73b493b2f0356ab5367edcbbc4878f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_riscv64.deb
     digest: ee60eae4cb4d4beb724ebdfac90314aa13ce4963d5292d61374719f919580d40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 2dfb7fc313c90cbbd9067dca8b83ccc6dc520b891425f5a9be30d4bf9b19f687
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: f85b878c15a095299e114e5a1252934764aa4fc23736f2d34aa147f755094655
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 7aeed974cf6ded36968fd8ca0f5550a95cc3eaa1bd934332bce33bcec5561515
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: bfff6c94a3b1bc735adab6d1c4c6023d47be2ced2fda468f06d5250289c46bdf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 597a35c004a9e6567230475564b09e0c337afcecbb1ad8492f5e4c49cf40b749
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: fd5dbd1222c0a6fb707ddfd149f0a037d43d5a86e04685f5d496be90a23d9e7a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_riscv64.deb
     digest: 31c4be6f637365f551df3227ea19c43ef2bfc612ae203abdac1f0a048415b553
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_riscv64.deb
     digest: e03df7a7a8cb4aa4421e9e1967e1580ae1e9dd0f86ea0e0183104fa165017b5c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 4f3697af78ba070046b0baa2779c81e8a84c9685271d32b8f836c4d1d45ba01e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_riscv64.deb
     digest: 06ce9a2fb3687d3d765c94bc22ce5396c4b4c1fc877910b332fe36ec02615613
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_riscv64.deb
     digest: 56dbc795c1e137250f02f7a31f59fca5d9ef41c05ed2b6d750c6d692e0f0d542
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin9_riscv64.deb
     digest: dbb104b39d830c24eb3df096968437ab10225bdc32c7a26ab9f0df4f3053afa4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin9_riscv64.deb
     digest: c04840f3dbf93050c9450fcb857c89dad390b203b3aaecfc868020f2cb8681ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: b31c5355c7b02aaa94f0eca0cecbb60c80945c5c1bc44631a587ce11c8fab724
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin9_riscv64.deb
     digest: 58867053e7f115b6d7ad38e9b1ebc17d480a89f60432d5f844e9f55a52c44765
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 171a2bd5d68f2d138a359a2bba9847acccf549e9ab27c8777128b6df040db882
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_riscv64.deb
     digest: d7147fd75ba6e867a4b5150fce61f07e8479b9f02963c50bc7af87f2ee7b5168
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libr/librist/librist4_0.2.11+dfsg-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libr/librist/librist4_0.2.11+dfsg-1_riscv64.deb
     digest: 46e19c19546d84eff60048872f5445b16e72b8ec883e703ec7f236219f203a88
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_riscv64.deb
     digest: 1e7da0c01190e31c826a663e66f25e0da593cf34d6d5981049230c8454ac6cbd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libsepol/libsepol-dev_3.5-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libsepol/libsepol-dev_3.5-2_riscv64.deb
     digest: e61b8befaffd5fb6d95ebee86b3ea041fc4df4bb5c94f83a473b695bea849209
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_riscv64.deb
     digest: 37c5d5ec3a331da214055f608a31da6e7e2514b47ffe4c6abff080015ace38e7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libsodium/libsodium23_1.0.18-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libsodium/libsodium23_1.0.18-1_riscv64.deb
     digest: 30914902997307d89afd39d210e984254f3c83de8d51adce058d41cce8c01937
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_riscv64.deb
     digest: 6fb11fc06c27a21ed5189d5605a26157afccdb605bc843aff05dbb8b583642b2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_riscv64.deb
     digest: d36ce6ce1b62c930a8fbecaace0b3ef0825ba6d02348778f5e76a1cf808d2bfe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_riscv64.deb
     digest: 7f9762d2444169e444bc4fa3614f8be9cd1093350dd41eb961c887531ceba4f7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libs/libssh/libssh-4_0.11.3-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libs/libssh/libssh-4_0.11.3-1_riscv64.deb
     digest: 83e14ef60d6b8011a9bbebe48f69fd1bebd99f3f916180c1173b0216545d1033
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_riscv64.deb
     digest: bbaa03a76b6ca6f7dcd6647d8413ce29c779e43d0e8dd999ebbaa91f9f21df4f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin9_riscv64.deb
     digest: a900893f82e76e974a0c51cc54e1420ff2f05f197c4ce3c7f2d825656051ad62
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_riscv64.deb
     digest: a81767e023eda57d5528e6084da7f01ad06aef316129a4804585f95bdcfd7a37
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
     digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tiff/libtiff-dev_4.7.1-1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tiff/libtiff-dev_4.7.1-1deepin1_riscv64.deb
     digest: 02dcb3ca9d245dbc069ae335f98224bfb39c9f2fa49876d53a26e920e6d8faf6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tiff/libtiffxx6_4.7.1-1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tiff/libtiffxx6_4.7.1-1deepin1_riscv64.deb
     digest: e4ab0f5d4f9b9374dae94ac8bd7739aae554f8d619832fb1fa7be3886068eb49
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_riscv64.deb
     digest: 7f1343979eb3ca64474b735fcc48cf3fbc04126a3845e91895ae10ab2197a3b6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/t/tslib/libts0_1.22-1+rb3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/t/tslib/libts0_1.22-1+rb3_riscv64.deb
     digest: 06a0f14a72b09fcbc2eb78edcecb99e3be3e113726b3c82f86b5af16981853db
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/systemd/libudev-dev_255.2-4deepin25_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/systemd/libudev-dev_255.2-4deepin25_riscv64.deb
     digest: 094bbde9397e7aa068763fa1404f62af407af3ba078fab552d5d699e87c1f496
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libu/libudfread/libudfread0_1.1.2-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libu/libudfread/libudfread0_1.1.2-1_riscv64.deb
     digest: 0367ec4150f43bf01bae030a9e1739f0bf8048dc8d25fd878c62a12986c95e2b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_riscv64.deb
     digest: 4bf1961ea6c45dccf1dccc41ee5a6929656ce17e4deb1412bf622e6bbc3e08bb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_riscv64.deb
     digest: ca14c41769b5ef31000973899a08430256cf98f2348725e5428e107e487d4db1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwacom/libwacom-dev_1.12-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwacom/libwacom-dev_1.12-1_riscv64.deb
     digest: 330b8de6916b128e899604f5ffb92b25298df5098db1dcc31c98fa25aa9a79cb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwacom/libwacom2_1.12-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwacom/libwacom2_1.12-1_riscv64.deb
     digest: 498a4767e58ca9868acac5579e0bbdac1eb35ea35f419e0893b2bbf967eb0aaa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/w/wayland/libwayland-bin_1.23.1-3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/w/wayland/libwayland-bin_1.23.1-3_riscv64.deb
     digest: dcc81c685e8c562ac778009422ac1daafbc1b7e444e2a0cdf7ec2cde870cef9e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/w/wayland/libwayland-dev_1.23.1-3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/w/wayland/libwayland-dev_1.23.1-3_riscv64.deb
     digest: 7459e34907cad410ed0e3ae782c328f73b6ff7221261dd7b6ec6980e7fff4d1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_riscv64.deb
     digest: 7af93fd9ae41fbb58eb92e14a9af85fdfb99995ca271cac2f7931535aa7668ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_riscv64.deb
     digest: f079e4466da41aa73db79f49170916b73fd67c7682152a554c0fa08ff3b74eb3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libx11/libx11-dev_1.8.7-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libx11/libx11-dev_1.8.7-1_riscv64.deb
     digest: 9e3d4a4daf77dbd70e768ba6bfcb5d6212ee5befa887167d362cfb5d5e0e7c0b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxau/libxau-dev_1.0.9-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxau/libxau-dev_1.0.9-1_riscv64.deb
     digest: 9c56bcf34da29b6562bb6f9f2a9a2b6fabae5999f077811abce30694d38d4cf9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxcb/libxcb1-dev_1.15-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxcb/libxcb1-dev_1.15-1_riscv64.deb
     digest: 9333c28df208e905fb6c8f56e02c3287d990c4eab0510bd8afca2ac336971ac5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_riscv64.deb
     digest: 1046f66278e6bafe279590f5aa0c8020b2f0daa429479d2d78397f78568991b3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_riscv64.deb
     digest: 7f29bf0ee322ea6e30a0b5bccd80de703149d31ce9ea7a5c8e6e21f4b1f810d8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/z/zeromq3/libzmq5_4.3.5-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/z/zeromq3/libzmq5_4.3.5-1_riscv64.deb
     digest: e9c4cc06172fe4cb597a23d91538bb797322890a698357d6257a5a84a95fd7ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_riscv64.deb
     digest: 13435b1929aa7177e5807071669d3f930ca829d7a7a2e0fc38918c4693241bb0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_riscv64.deb
     digest: 5fadba4d8655ff36ad7ad19ff9e5e2d655968683690b1b707a1b85cc58a1b8ef
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/lsb/lsb-base_11.6_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/lsb/lsb-base_11.6_all.deb
     digest: f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_riscv64.deb
     digest: fdb9d744dd605097334a0bf735722ef29448fcb5a7e60651156028b4dfb3bb88
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/make-dfsg/make_4.4.1-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/make-dfsg/make_4.4.1-1_riscv64.deb
     digest: 7f1320a2e33a5b9819a683812376d245321624f2fdc605da48eefa299c38c792
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
     digest: 848333f2b40b586ecf8f0db2b6127398d0423867e689937c4427ab15570e5581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
     digest: 729d9b051d2dcda0d0bf51fee21d3b685093314a0b2283926f1eb11f937cb04c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/patch/patch_2.8-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/patch/patch_2.8-2_riscv64.deb
     digest: 28b1b35da9af64472c3dc5361d962f3d036d1217042898d0f060114c8672e41d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_riscv64.deb
     digest: 2fa162b1edf4209e2205220ec902a413a4b73122f90739f9f4f73b546c677bc5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/pkgconf/pkgconf_2.5.1-4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/pkgconf/pkgconf_2.5.1-4_riscv64.deb
     digest: 4bc6b47e755e58dfe5d2d54f6d775aea604f5832c3bc234ae5f829e7c761ca76
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
     digest: 4b0fffc886401daa9acfb53e2b190528e3fad37a49b989c4fae6715004fda41e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_riscv64.deb
     digest: 107d2e06b689d0ecc25d7e70cc7de5302f26f7cdb9a10fe7ac66d2bc8958f098
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: b0c34202db0282bcb48a758e7917d33cae35521ecf1033307a83185a69cbd725
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: eaec05eed7d032446cb6375c0b2e4b38d24e3bc3b73276a0b63cbb76b5b77bd4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: dce9cd5c1bfe1377987b57b9adbd1256845d85a2f483ab3e3e6553ebb6917726
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 8ecfcf8110a34b73abaa0d506a7533babbc4315f4d1fe89bb367c650ff5577c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 472274df07791b5c805a0f9f2ddfceeb4820743cadac01b878ba5d2d420da733
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 74fa8e9b94ef44aa021ea369c5fb820405acbf564af08082c6368f7c13b14ab5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: f56d0d0f38d44346b2335571194ae4cf58605f018c434ea1c4043ba123738b70
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: d225188d0360f977b6f699a1d950b3579d63f678c2b3a590bc3802c5ed3f7cf8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: bb992ccc0f9ed9f821ed843081d204c3bd7d5e5066586048bf2b86eb317a15c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: e440fadb73da935dd9360d38da1e1430307481a67e8bfce8656a119ffa8c1551
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 3e6cd846348d22c4d9f9177b6db2eb5915be587e3ee5636668653189e77f5abf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_riscv64.deb
     digest: 72c48c137920f33b0d91856319ea8ef9c89e9f595bd3eb2bda6f386451bd5280
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: a4c8044ea50054aa185e105cb13a956ea39f21daf6c57f13f132f1c345f5facb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_riscv64.deb
     digest: 06ad674af83e6014f879675f7580099ed3b10e5dea80288a293ef0714ca96452
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_riscv64.deb
     digest: f35d98f8878d3d20c4b26ec3a0c91ec40f4b7b8049a0bdcb98923f226128a90f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: f27827d5c877e357db0aabece8389359a8bef5a227f9b2f15f52bec1d67a7c57
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: fe212ff7b8b2feec77d730f989ab0d62a7495ada13b6a2aa4ea5cf81c506d7f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: b3bcbe4be7f4cf383b0ce33ea6522b09192544fefa5f8fd4df1267fc22289445
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 48dfc247469cc3d5c30aa6819739fecbcfec569273a4e4b380b8a0206caaba09
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.43_riscv64.deb
-    digest: da6524b627da3cc6126d946b5c3837eb78762bc5ac934d25fde7f6e53da424f0
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.44_riscv64.deb
+    digest: e30617fb185563615a4222bb519f991041241cad51a2b0c973cb283b4ec6750e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: abf68f81039d2b7a3c122828c29cf4a236ca838e0ff0f492f7244adf30a6b6f7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: cb99a8e3efcea8ad31bd336d0dfc4307f948d0342bf7ef9060b807f9788780c6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: bdf9e7bfc3dd5d610558dd51627496590880680c55db4f1a96456ba99d689514
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: d084fc283345e3b50bd450a135026a4549f1c65d431a6ffc7f8664f8a2db83d3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 98cc5f0f47ee9263d00ac3307ad3f540fd2a54560764ffb509166806b6a12546
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: a557b87bced82db1318f1a3af03599c8e08692af096cfd89a6424f3d7272194e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: f9fdb86397e61f3cda27eddcf060867946a569c1678feeb632760883ec75ce0d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 7049b54b59c40d5da4469672c70f147ad20976e16aa1a6b91b3eb33a05ad469f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 6e79540571af7728c186c6eb47e97427df2534fbbd6f2c36a6437152106b59ee
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 8469c2ccecb6c48e43755cbc1f78cb79005e4846edc98d7fd26fc35edff8dfae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: dc9e5124a163469dbfd6bb90270bf6b4b7669f417cc1b0415b76f735890a2fd3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_riscv64.deb
     digest: 42c80c39ac07ca91cc36f68fe487f34751f4f31c5d3d88aa665a5cbf247f5ce9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 05d8949a36b0bbeff983c671ccfbaf6e515b7e98664dce8c49d4d12d41a5bc36
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 53660026eae688729ad996dd0176c00724bfe2a1a6ff805befb5ca9f7e83880f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_riscv64.deb
     digest: e7332a9bc72d9f178d7e787a1997f80e7d35363d54a3e8e83f1ea21326c52371
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin9_riscv64.deb
     digest: 2fd7bbb87a890b37662507ea4f383175716552ba45f3af6ce00054ed7e718651
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin9_riscv64.deb
     digest: e15fe5bbc286d10d7a9fd4fa7793808ec82038b7a99e477adcaec7dea8ddd2f9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 20d14c8dd31c45de944db6ff833641550b7c0203064c79a475e7c5c9aa66a851
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_riscv64.deb
     digest: 1a250862673fa606d4ce3b230b15f33bbbf5bbfd28205027953b701b8b64bbb3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: c27b778392bf1166b3c7e8510b42b2ba0ac9226938d1cb00dcb8b3990b9c2410
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 877c84e77870ec6fb2a0f3c22e2f65ce27d1e23dd25ca377cb7ffb157a0b8915
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: f6061c4a1ec44c5b2fdd5f5b349cf3636ef81910273bc24c870df18ba65f8597
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 0607c1673793abbf7802df9940568d97f985a68b878420c26d1d518a51f50a30
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 970c74e28947bc4f5ac759cb4849b74a82fcd9e212e6dfea7d8adcdbc71e5f89
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: d54490db29cbe2cee2772ebc76f5081f22e3d7e481fd12a2c23f2dabc9536194
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_riscv64.deb
     digest: fe0da86d36d57226a933b280aac8981b23edb4e404fd9aa2495562fc8a5787a6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: ac9026d7f2bfba7593647a857192bf35bad26087c4f4018d168d3af299087694
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_riscv64.deb
     digest: f93a56d4ca50fe6b92bbb3281acfbdc7fdf22dbfa96d02bc8809b7e37600ed63
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_riscv64.deb
     digest: bd04d588bd8509af14c4e39e50c838aa0c88f03e0c6f2f63288ad5c858ddd18c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_riscv64.deb
     digest: 4cf454ca70238ab58447c83ab6ae39aaf9f98343ed75c87f98e52c22b6d820a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 64798346bfd3e8e73856d57c016561518a4b054cf3c371fb4dd371d240b0a70f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin11_riscv64.deb
     digest: 87f83da9bb7980a27926b70ac0eee810c387f2d78cca4a0956a3b17af0016ceb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: 2cb255493aec48f679d1aeb8b08f31127a8009ca4083a12fa5816aaf9cb0b866
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_riscv64.deb
     digest: b1c3249a98e45b1c23c176681fcb465c7f966e5a5ddb7cc15158650c67518b1a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_riscv64.deb
     digest: ffb944b5b7a23ac642f511e42b80780eeda9c6045979bb8798db9555e4b1709c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_riscv64.deb
     digest: 5b51bf9d674d82466e3604ea415ced720bbe6845ad111b94adfa4b6d8d1091cc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_riscv64.deb
     digest: c8d467a5ac1d72f17bc36972d2646ba4cfa4b1145809b2e4fdafce5f4cc99071
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_riscv64.deb
     digest: 85ee44301d4eda2dac59d8601e12504a0c78e259a6c845ab7be5f2937604d132
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_riscv64.deb
     digest: cfcbdb6abc4b9d81dea9fe8a1cb63757e8bf244a4558c39ac3fe4203c1ba9cd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_riscv64.deb
     digest: 6978dc2163e40aa4987559f86ef0a19688e53b1f4b64a5bca0370e49243e053a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_riscv64.deb
     digest: 0c5dfdc1401ac799dad22fd7a9c8ee8e6ca50c78ba2c99fb9565ee8ba0a8d14c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
     digest: dbfa88dae0e66fa60e6558fa80242bb78be8dec5b37ea449f85826b1b48cf25c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin9_riscv64.deb
     digest: ca86726dc4e2e18061b969ce6f9b077b5a232f8cef5a22baa189af208d90c3f7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin9_riscv64.deb
     digest: b30ec1b1715c9e462ef30eb62bed586fde0143e1d50c11c7f512c4294e9d09df
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin9_riscv64.deb
     digest: d2e41438177068f161ed4ff878f2b7e1ef86877c2332c9761caabc622cf79646
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin9_riscv64.deb
     digest: feb6bf075eeb057fc034187c8feec9d98bc0575f97f13e0824b59ed652c5ccaf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
     digest: e70bbe5b35aa1009f8d3e8d58634052977864bad1d854230add6758ef238b1bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin23_riscv64.deb
     digest: ebbc163daa6e0d61a9161c7bc1b624604013add4ef04f78f39ff0ead76c93ef8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
     digest: aae8ac2b6d3198d297d430cdb97e556365be2ff46d06525008ce071d97ac69c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/uos-license-content/uos-license-content_2.0.7_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/uos-license-content/uos-license-content_2.0.7_riscv64.deb
     digest: e0d9457e048d8652ad3fd693a25557fe94546ff4ba2e04cd1fb0ded4eeeae041
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_riscv64.deb
     digest: 754b734289ba79ff9fc732a1ef0c5baae57a7eb0073941f9b39a69f6fdc04014
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260617/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260623/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_riscv64.deb
     digest: c2ad747fc268726e4ef3f723f1269428c221e64209c7ffe8aa7cf86e7a56dfb9

--- a/sw64/linglong.yaml
+++ b/sw64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 25.2.2.8
+  version: 25.2.2.9
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2

--- a/update.go
+++ b/update.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	deepinRepoURL = "http://10.20.64.92:8080/crimson_runtime/stable_20260617"
+	deepinRepoURL = "http://10.20.64.92:8080/crimson_runtime/stable_20260623"
 	uosRepoURL    = "https://pools.uniontech.com/desktop-professional-V25"
 
 	deepinCodename = "stable"


### PR DESCRIPTION
1. Bump runtime version from 25.2.2.8 to 25.2.2.9
2. Update repository snapshot from stable_20260617 to stable_20260623
3. Upgrade DTK packages from 6.7.43 to 6.7.44 (core, gui, widget, declarative, log, common, data, exhibition)
4. Upgrade fcitx5-qt from 5.1.8 to 5.1.9
5. Update all package digests for new repository snapshot
6. Apply changes across all architectures (amd64, arm64, loong64, riscv64, mips64, sw64)
7. Update deepinRepoURL in update.go to match new snapshot

Influence:
1. Verify DTK 6.7.44 packages are correctly resolved and installed for all architectures
2. Test fcitx5 input method integration with Qt6 applications
3. Verify dde-qt6integration and dde-qt6xcb-plugin function correctly with the new version
4. Test chameleon QML style module loads properly
5. Validate package digest integrity for all updated packages
6. Confirm runtime builds successfully on all supported architectures
7. Verify no ABI breaking changes affect dependent applications