### PR TITLE
chore: update linglong runtime to 6.7.0.45

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 6.7.0.44
+  version: 
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -13,7 +13,7 @@ build: |
   bash -e build.bash
 
 sources:
-  # linglong:gen_deb_source sources arm64 http://10.20.64.92:8080/crimson_runtime/stable_20260708 stable main
+  # linglong:gen_deb_source sources arm64 http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3 stable main
   # source package qt6-base
   # linglong:gen_deb_source install libqt6concurrent6
   # linglong:gen_deb_source install libqt6core6
@@ -179,818 +179,818 @@ sources:
   # source package uos-license-content
   # linglong:gen_deb_source install uos-license-content
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_arm64.deb
     digest: 8640b3a520c753202b7522eb12370205694c88cd354b3b24d4bb5fd25d51fba2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.41-6deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.41-6deepin11_arm64.deb
     digest: 49430242acd8bdb7fd942ccefc4ef5f9327e73534dbad5e15641670f1eb123bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dbus-broker/dbus-broker_29-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dbus-broker/dbus-broker_29-3_arm64.deb
     digest: 85ea96ecd1c36047a88b101d796617cab7fa4158f08180e7d275c799fb1ad97a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt5integration/dde-qt6integration_6.7.44_arm64.deb
-    digest: ff7de222e4eb59cced2c0ee23a64a2332080dced149e271d6d25e8b3dc1b51ee
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt5integration/dde-qt6integration_6.7.45-1_arm64.deb
+    digest: 70ac26ce1d423991fcfce38d4b303f5ad85d02696c285fc3a57f00b253b63ee2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.44_arm64.deb
-    digest: e89f739720d72dcff81ba20765349a5cd4d22da16ab6b27c837465e25deca08c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.45-1_arm64.deb
+    digest: d07728e721d46145ed8462b0edbb517eea2a37eafb970226df50e2a4f9147cdd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_arm64.deb
     digest: 14c2e40bd300f261f972a8f029e7276efbb5d800c5c0ff32cfceb3584f8529a2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
     digest: 56be397887b8d4a953202fbfc4342e7a675ef386497abaf0d7f95521340c28a2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
     digest: ad27e359a1fe3485255ce3c17eab99ae42ce1aa03acd67e45a2751710dc463c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.44.1_arm64.deb
-    digest: bedf3cf6c86cf8fae898d60e62d9f9d364f92fc0b390e3044d1a70e6ccfdda62
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.45-1_arm64.deb
+    digest: d3e89df905fc189056bae828fb72a0321f051c81d4477c9dfd67dd0a12d9eb67
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.9-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.9-1_arm64.deb
     digest: c70fabca6786d7044493121c291665b035c8869310671563088d1d799336e2bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
     digest: fafd08c872d1279aa0bde2e0bdf40a57721961934c0593352b6a2c551aa232a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
     digest: ef932bad267f9d4d49c0c376ae1d0fc1a9b595054f8450d42b2a0d6621bc7084
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_arm64.deb
     digest: f860cae29e09459e0d4e8eba441c6f3cd653f0d324524d4a92b59e6aa0c70dd3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin9_arm64.deb
-    digest: 48de304ec3a97a94911a533935f6b4fe5e0dad63e1c0971633f8c26772a7a660
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/ffmpeg/libavformat60_6.1.5-0deepin3_arm64.deb
+    digest: 4e50b37be1f3d1445b3438ffdb05415431bf5686f56b2a1e935ad8e95b54ae9d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
     digest: cac541f3cf746d006b71a08f88364b6743222b8956fda9a7cbd35ffb1cf32ed9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_arm64.deb
     digest: d95934f82db8aedd2ee282cd44e0088363b484f99fc679ab2992d0109a079518
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_arm64.deb
     digest: 321b50e4ee0efc4aaa9e67168e4b88216733e1c012d269e6e9f2c04941a66ec0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/b/brotli/libbrotli-dev_1.1.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/b/brotli/libbrotli-dev_1.1.0-2_arm64.deb
     digest: 016574d411e89311351ae6117b766a6bfa1ef7c0f49a4e17601200a33c2a19b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_arm64.deb
     digest: 502bf30d0f5d2a06d33495526cb4f5f7929623e87ed3c716aafb91f29565c1c3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/capstone/libcapstone5_5.0.3-1_arm64.deb
-    digest: 69c419efd4b58c93eadb583e4d1465b9d91355a3eb599c3d6ac0dcfacb685d8d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/capstone/libcapstone5_5.0.3-1deepin1_arm64.deb
+    digest: 50a75abe8575c7360584221c38644811654a9d9a9f2ee197b9f48afcace592c9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_arm64.deb
     digest: 39486fac0b8bd52f8641e2586befaa00aeb6a03106f3b6c99e64039c8e7b4a6e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_arm64.deb
     digest: 0a6ac3348d454cf7a354cfaaf03d67a74c12168356fd5cd896919083f1d3944f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_arm64.deb
     digest: d6afcd6261c54705b8c631dc598bde29ac135bfdce8befba68ee4abebaff8189
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_arm64.deb
     digest: e7ed6d3eb913cdca3b70df28573917194d19c5dff9e1f7b3989bbebb9f02e6c4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_arm64.deb
     digest: 7b3556881a1197e81b499d39c6cf38ac7c7108df05684c880fcce3e434f9ff6d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_arm64.deb
     digest: d9d85c3bd18fc8a2bb701abc9550f9181797a25ebd1f2a0c4e41c2cc4186d7d6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_arm64.deb
     digest: 3c9ab42334735ffef9fefe39236a25a5c081440ba0f0b0ae4c536a4baba81eb3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
     digest: 78e9245e377c8f61009cc60d2b55001aaddd7b656fceb916b3ba8f07344251b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
     digest: 5ac1e65112a190dfca99abf002e3e3f0ee033919b7b65cef5e3637ff1821cc9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcore/libdtk6core-bin_6.7.44_arm64.deb
-    digest: e1519bff5d68bc9a25b12130e8413d08340bc5b6e6d9533f38f2fbe0f445abbd
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcore/libdtk6core-bin_6.7.45-1_arm64.deb
+    digest: b2536808d99104815cbd29f71a122c6f8b0591f1492dcb4bb4ab9d09cf44a234
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcore/libdtk6core-dev_6.7.44_arm64.deb
-    digest: 5adf87553cbe4f443516718412d7e19a54bdbdf409ecfc9b4539d505a7dfdd40
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcore/libdtk6core-dev_6.7.45-1_arm64.deb
+    digest: 1e37b4350c5a1f27175829272dc910821b767629feb53334dafe5d868de5cf66
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcore/libdtk6core_6.7.44_arm64.deb
-    digest: f00ae9ccb2640991802fb9a17ddde2dcf166a1d9a3406ec96299fab4b1500045
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcore/libdtk6core_6.7.45-1_arm64.deb
+    digest: e5a5abb07eb48efa053ea509b74e9e20fcb04c330e1d55a5a6b5fb9a8ccb17ae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.44.1_arm64.deb
-    digest: ba3d58258149042bb86067b59acfb3646d4db4e42615965f59a85ee78957e58a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.45-1_arm64.deb
+    digest: b07a041b4e5322c6335edad76da333845417f3dbe2f8eaf3e48373a03993cb0f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.44.1_arm64.deb
-    digest: 5feed68cbbd33db03e533d0480d56ac84ddcd24f35af27bee1664374442a5286
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.45-1_arm64.deb
+    digest: 0ce4c63aec2f3a2c66b5ea494d564d5f46f8f4094e63d74b429c74cabd406166
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkgui/libdtk6gui-bin_6.7.44_arm64.deb
-    digest: 82d5ccf9e27fca71653b563e37d5ea6c846f03e634526b0405a527a71e663d73
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkgui/libdtk6gui-bin_6.7.45-1_arm64.deb
+    digest: dda2128bb25476b20e80cbdd05d2c54e79c335dad72cc50d49f214e3f194bc0f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkgui/libdtk6gui-dev_6.7.44_arm64.deb
-    digest: 3985373e2c9704d57a1f6f3f96951c3d04d9f9b4897c4ee54b6269f9e688df9f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkgui/libdtk6gui-dev_6.7.45-1_arm64.deb
+    digest: d43a9ba4d8932dfdd94c619fdb91aed90983301449713142f2e1bdb502b1c2c3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkgui/libdtk6gui_6.7.44_arm64.deb
-    digest: 50057d0092188b2539b88c9031a0b2a6e452b6a1d26091f0c1e0b4a43e6afe43
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkgui/libdtk6gui_6.7.45-1_arm64.deb
+    digest: 1cf414122437d08af84fe4c3244df54f99691dbf4ef527f66a436c1bb42459c9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtklog/libdtk6log-dev_6.7.44_arm64.deb
-    digest: 51b1fa0eae00e5e07717dfae22f334256949fc2c69804e8cd0af6fe9f4d9781e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtklog/libdtk6log-dev_6.7.45-1_arm64.deb
+    digest: 5e2f30142b80fa9e036fb2c1db7b0dbc5373e7b59edf9449bf2d426e33de2655
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtklog/libdtk6log_6.7.44_arm64.deb
-    digest: f397a2518aad02c03a72f53f90278940a904181cb29cf550f79b54c0cd08e92e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtklog/libdtk6log_6.7.45-1_arm64.deb
+    digest: f3f323f5f3081aef24a6cd7891c2a15b395abded4e677e40da08ccf8b2969d18
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.44_arm64.deb
-    digest: 41231ab30255c22601e8c2bd95053330fa42cc0bed78c6950eb45278b799fa61
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.45-1_arm64.deb
+    digest: 172c3ef7c31f08ab1714e9414d1d0daedcfa66237a50ce55a6722b1fb3060eda
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.44_arm64.deb
-    digest: 9a35558f5ec21b648cc5b651c9ac6b83847023520c3084a76a9b975af9173ec4
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.45-1_arm64.deb
+    digest: 07e542b9e5355141d54404eb17c83786d7ccb357528a3f4ac91b06bba9437dbe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkwidget/libdtk6widget_6.7.44_arm64.deb
-    digest: 9dcd23757b5837dc07e2b1f5f41dd36b7d8da9c1d27b956bcdbace3a58dc9cb6
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkwidget/libdtk6widget_6.7.45-1_arm64.deb
+    digest: b3a0fa67265a61bb42d8181dd00e60ea2ed553a326466efb1529a9d81ecd6acb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.44_arm64.deb
-    digest: 0b59c4d0f6a9b3c249454854aded3cc64d9436c39830b0487d6c801e0ac6bf61
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.45-1_arm64.deb
+    digest: 258037a284878b4dd601ff07339d6b0d4563ad2ce621d1fa7ef51d7da151a46d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcommon/libdtkdata_6.7.44_arm64.deb
-    digest: 719bf3862f92937bc0d56d1fadabe1b8e612d2b7c82c4d3ab275b573efcee6f6
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcommon/libdtkdata_6.7.45-1_arm64.deb
+    digest: 5fd096d5ef8c022b7b022ac022f519eb6984d3ab340cea76c2084d9f53e24395
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_arm64.deb
     digest: 14c66f6e25da4f8f2bf1b53b74126adbed322071850c68cdbf47795ac59df996
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_arm64.deb
     digest: 8698ae77f431746eca65194045fd226926b6cfe2797e4b6b81cd720e9717fc38
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/e/expat/libexpat1-dev_2.7.4-1_arm64.deb
-    digest: ad7f54cb17830a0ddbad2492953411e37cc1d5d1036c567e5b057b70f30d5a12
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/e/expat/libexpat1-dev_2.8.0-2_arm64.deb
+    digest: e2ffcffcebf2dcabcfb0cd09f5528d229fcc1803084fce245b6ec24f463ee6df
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_arm64.deb
     digest: 9031aba011c7fbda1347bcbaf9351128ea600807b5f303835af17729e81ab28f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.9-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.9-1_all.deb
     digest: 095f6c357e994b15d51e9cf85722cbdf80f821a8ba2e5b2310fb9a40bb2529b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.9-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.9-1_arm64.deb
     digest: de6d77367b2ed4e1fa4027e43cd25e67064b6f8b45d47566e584b2036bd85005
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.9-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.9-1_arm64.deb
     digest: 8ed2a04860f0fa8d681eb7f6aa59c9f8a8ff9f41a7eaa21d7bd2b6ebcbf3cad4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin1_arm64.deb
-    digest: 3cd614e9c7ce6b165ea4325ac2b49b5df33df69d25f0f62673f5d2100ee398b5
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin6_arm64.deb
+    digest: 94bda74b48737ed502e09404eb4beacc2defbdbbddbd232f5c2adc458b352da8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
     digest: 44b6f1a9aceead0cac121cfd13cdd9a529eb2b60522f8482c7dc4f67432d1904
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/flite/libflite1_2.2-7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/flite/libflite1_2.2-7_arm64.deb
     digest: c78ff59f928670a34074654ae5506c4f021af1ba56d9ebb4ba82aa7e49a0834a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_arm64.deb
     digest: 510d2d650a4a84adfd68c2ca880c8b7902ebe8fa14646f8544252189caa22eb3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_arm64.deb
     digest: 4e86b2e07435f652e068a77a7ee30444b38e52cf84a5d5bd2564c86d76af9e3b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_arm64.deb
     digest: 940d76752d4d561b14a8b3109a417d83bb24d5aeb6e7d9fdec5190ba0bd12af6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_arm64.deb
     digest: 623fa8b60136b4dc9182483dd53b310e60823ec8e0b58a6156d079acce2759e5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_arm64.deb
     digest: ef605bf23fa580844d6a5faa61caf503f3825bc69acc9e30dab40689116a2627
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_arm64.deb
     digest: 7819d43f2aee082ab6bbddc14a8a0446e606299e9436352accd31ce2af0ab205
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_arm64.deb
     digest: e4b703bd44e05dbb28208e7b07325f91db880690786cecd3f06632e39e4e588b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_arm64.deb
     digest: ff60370ae98f4515ea9eda99af3ab9d468b53b23bdd22f4b51abf8064655e810
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_arm64.deb
     digest: 6be533a6b6cb8b661664fedbe661b316edd0bee46f51fe598d300c2efaf95728
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_arm64.deb
     digest: 49a17d5a14ebd80404cbdb696735b1cb8fe14045bc5bbb5bdec0372528bd18a7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libgudev/libgudev-1.0-0_238-6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libgudev/libgudev-1.0-0_238-6_arm64.deb
     digest: feddaaa5fe03ccd3d27cecc446c9392f18e5022321a3796597249b662650cb25
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_arm64.deb
     digest: 4ee7382858ba8b140e0110cc59475db2dea7ad0b56a21e825528e5a2d0d1f7a0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_arm64.deb
     digest: 1af178c5a43fc3f1a40d90a4890bf8a00372449495bc32e6ddd82165927b3591
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_arm64.deb
     digest: 787936458a32bbd6da2c8eb749f831032036ff8a2e1c96644d56760777e9a3ee
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_arm64.deb
     digest: fc130cb8c18c9b08c7eeb72a9a7d340d844228417e36acac217ee8fe93e60150
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_arm64.deb
     digest: d42f1915689855e67552d66c8ac63370fb5b93e898461560fffcedbeac8c0ec7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_arm64.deb
     digest: d554b612e70c2416c6d831b575c1bc1c3f4c0143454ada80203e08f918143e77
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_arm64.deb
     digest: 7eb0cf9914476bdf669f0087c7fcba1d0cfd49f9697804d72fd2869e6fc3ecf6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_arm64.deb
     digest: 4355b250325f762945b8d68dbb1e39fd0847230f9bf56284c35d4a69aa819e5a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_arm64.deb
     digest: 1084fe140088878214dd72f6c8ebf4f4835b83f542ed443ce79cc2f43821d6d9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_arm64.deb
     digest: 82d472f20711c3b0eee4afb2b8bc8a0971f6fb7ced7612317f07597768e6ddad
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_arm64.deb
     digest: 0e91a2383f5ab980fb06cb347c66dc6b6480a7b76cb67ded44bb4b183f295d21
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_arm64.deb
     digest: 9516df25229fcf17ab431b82f89da91c6defb1aad63df171ac3370ba0fff48cf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_arm64.deb
     digest: 485cbd67d6d1e4939265893887a62e97d80190d524f5373f78d5ddaa2f22dcb5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/md4c/libmd4c0_0.4.8-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/md4c/libmd4c0_0.4.8-1_arm64.deb
     digest: 8b58cf124cb0a435765f6cbc7bc8a59d431a8f84babbc2956beb1a46b53b99f5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_arm64.deb
     digest: 15763cf880b4073ba036e05f2a3b9b46aa43802f9d2c49848fd315a9229d9be8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_arm64.deb
     digest: d3b3c567419dffdf8395282df0f2a766320a8071bae29509155e68e526cc7d87
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_arm64.deb
     digest: 17fc6b739d5d25e6139f8786daa9ac90b81315dfde9df401d7a8896831bc1828
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mtdev/libmtdev1_1.1.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mtdev/libmtdev1_1.1.6-1_arm64.deb
     digest: 646172dd88b260728ef1da45a78d41c78161a8341d0ce43de738c63f2e4089ca
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_arm64.deb
     digest: 06f3609b64811a80941b259736bb1f71a58633df1300b979a4458fd92a3d634e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
     digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_arm64.deb
     digest: 218417ca4ee32acb47bd698999e03414161810f034ee895f54a75ed79b15345a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_arm64.deb
     digest: d52a6102a07d9cff9066f0e3ebd802ab14e119bd1f9a890999be8cfda4c2cdce
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_arm64.deb
     digest: 04f4ffdf19ebd3ccfbcbc32489b3fc651ef75dd1b33cae10e5ecb3c8c4287332
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pcre2/libpcre2-32-0_10.46-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pcre2/libpcre2-32-0_10.46-1_arm64.deb
     digest: ce2687d8eb755b1a3a7cebfc0fbbd94c2ceb01e7fa4dd7f84615c424a91b3427
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pcre2/libpcre2-dev_10.46-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pcre2/libpcre2-dev_10.46-1_arm64.deb
     digest: c36a3f37e6ac821c11b69b2cc0fbd23ee36a526f69bf249f2f32c566b24928b8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pcre2/libpcre2-posix3_10.46-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pcre2/libpcre2-posix3_10.46-1_arm64.deb
     digest: 83bbfc7bb285e5791b4b3eeba00660961f16b202349000766960c7c8e77b9604
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_arm64.deb
     digest: f09601fbb60184cf2257b12a7eec5e39ae0d8659ae517bb42de686abc791f5a4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_arm64.deb
     digest: 12fa81b09fb516592aedab42ff8e70c82f1373d5d8534e8f2f566047ba3e12b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_arm64.deb
     digest: bec072407ddf1d5993b7449c17872075d8215e45064131da0e7b749de3570eed
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/postgresql-16/libpq5_16.3-1_arm64.deb
-    digest: d1cec167267a17f161a55acebef996462e7a4244d41136d4bd27ea24c7c2faae
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/postgresql-16/libpq5_16.4-3deepin1_arm64.deb
+    digest: 2632a9baabbe9db656ed33a7d1d7f6caafedce6d7d3aa488fbfd247f4bb5c95b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
     digest: 3c2fef66a85ca8d8219283c1402eb66500b8587fa4f4495d327515e12b71e710
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 86373917c039da2a39fd3834950fc0ad38fc2f7330f195dc9c3c2f7ce3de49d4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_arm64.deb
     digest: 503f5c8e330d3b7cf0bf0ced200124c129b4157dce1f4f9ff2d9ee333e30ffa6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 393e94bf7829ea3ad45920afe021baafb613b9ee10ba453efc3d6fce964a5fae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 9ded8562957341771d20fbfd4fc3b0f39c26dfdbb1f9df3d06729c83ac742375
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
     digest: 1a53ee6f88e873fcb1a054617b98500f02b09cf0336a96be48f1c3467bc5d777
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
     digest: 1f2ad8c7d25fbd354c77a502f365fce9227af547a0891450fdd82e114c3ea219
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 9b254cf95fe0dc8c80c277174194d92921394a51829064c9cb80209a18cac30e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
     digest: a3621bb01bd9bdc62bd2896bef51cc01db271694a10cec7841c47c33507fc465
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_arm64.deb
     digest: 4f28fb916cd81a9d1275944c7d7b1215c67c9f11782559c49d289af2c9034d2f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_arm64.deb
     digest: 4e437c832e71179df54f516e31c37fae3436b9c3b0c6900c2649b17c0030788c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 74879566819e5957599f84947a6948629cff9a91ec5c95e7b3e7fd3e5b8dc1f6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 1fd97b51edd93f86a1e0069bfe98adb4970d9dcb59de824e4ed7c95dd5f40976
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 891830adeed08d767c981e2aecfb335b8e41f5d74dd8fea1a0449530be92007c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: ceb47ef24974033efce540080ec53937b879a9037ea0bd7a0462dc58b44e27ed
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 6f62c14e01fb139dec3f027c70eb1eff18e986573985d4035c565c84203c2a48
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 64d1c52328fec529d1218cd5cd2bbc8e6fc05cd807db151e15a43923e9bcad4c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 8f55716a49dd98cbc2c58d13e17e8640f5209005a666f53a8b81d089b900a98c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_arm64.deb
     digest: f6209c88dcdfeabfe2bd4954c80ef551c8a2dc674a13f91ba018cbb2ade1628f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_arm64.deb
     digest: e1158dab50cf7a78709684e2593b7f5909acbbb15469fa5e8a9bc08af1663203
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_arm64.deb
     digest: 35ed2555ca02d69c8d8ec4c2d571077637e2f5e082eab63a430e4a23e178ffaa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 999a4baa2c15f1fe85b0647c5fcf8a50b3bd1a1041887417c48936db60586067
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin12_arm64.deb
     digest: b36e994972d87a2349727ab12105c40019cb7f392ea2c4e32f63e4370187dca0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin12_arm64.deb
     digest: f4d3ac1ae7318e2c1ce83f7175bebaf380d5fff31883977d5d0ff54317042321
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin12_arm64.deb
     digest: a358cae64876f3dcc95af500e0c4116242bdcb592594d89e6b311e9ce00febcb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin12_arm64.deb
     digest: df05a6f78d7f0bb1d5cb0b7a85ec4aee90d15ceea3230789e623e1f50915b118
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 2580a8c08c89870ac3feb166573e8fe3e1c6144068cc6b89ba697c8344529142
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin12_arm64.deb
     digest: b426031c097492580703f5015af7ae16bd722f43efd3eccb6f857769a7dedfb6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_arm64.deb
-    digest: 6580d46c45a2b2a72aead40acfe67184e7e15149ca0737d0a594c11f750daf2c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin2_arm64.deb
+    digest: 88d149b52906992c4649113b79f690cae623ca3f70dad4d74dccb0d1b549bed3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_arm64.deb
     digest: dfe144682ad4f6fc4c0ca580a9b578686cfc69b079e4ce4703d9f20e38abb01d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 5a6f88b47744b81c0c9c22e64fccc2ec84f1f1430341814d3cbe29350ed50d5a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin24_arm64.deb
     digest: fae20257ad23223fafc3d4a52108cf9f2ff98ed907b96f81ddc3367ef40b1e34
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 68bae6cd07d1564fd42db49dfec15fed8bcecff2be76b0e4535a64a038e92e34
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 419a490fdd4bf32e601a9faec123741b032c1aa83dd4222646434d1829e2f069
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 7656b4872afbd122220d4ecf8addb31a898d60ee23a73294cbd3b1fee621692f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: be3b38189145d498dae3536d66f4dac137b31d89b49696e7989b3407b0aca038
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_arm64.deb
     digest: 79b08b05f818183d0170d8d315b3aca33a2349a3fa77ce3541a2a9f91c73dd68
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_arm64.deb
     digest: 6b089a1257327d7bf8065d636aa9f6365b37b3dafe4ef882c98b633639a7cae1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 2e6caa69092cd749d7069085b375d763341ad7a4c45158f40abc1549b544cccd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_arm64.deb
     digest: 8191eed7becdeace0c4422bc16c9ec59f2969c83a5289030be44c23c2a64eaf6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
     digest: dfcb32d2b4d90dde2ebd86b2e8376af1f7d5ad9233dc2a943f4144069de82aad
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin10_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin10_arm64.deb
     digest: 133e2fe66b69771e5199d693334805e066993e4cff99aaad6b09249a869d1051
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin10_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin10_arm64.deb
     digest: 44dbd9d34e0bef7ef2f5ae37cb93b46ef967e3317fd3179d4aff44bc8b38cc17
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 3e2a1f5d38ce3fb2e97d265a44a6a0e8e64d36d10f6c9b83ac71e26a8519cfe5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin10_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin10_arm64.deb
     digest: e2443bcfcab947b3b6f5992bdaae065f3b769fdb72db2108cda1f25e2e74d799
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: c41bc9e9c6dc37c4770d66f4278dd749a3c88e15a58a482d9282181ffa87b259
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_arm64.deb
     digest: d38dc8bd34b4cf0fe94e16797f662191b91eb9e16f9f0b44bbaaa9b4b4d736f4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libr/librist/librist4_0.2.11+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libr/librist/librist4_0.2.11+dfsg-1_arm64.deb
     digest: 8f3e4470689ced208c9d8253f5f312cc72795d27101adaba0bbb10a274c49b73
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_arm64.deb
     digest: aa09e909d7f1ba4c18ed4aac21d5aac26637731dbc0580e01cd76ee3cb8103c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libsepol/libsepol-dev_3.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libsepol/libsepol-dev_3.5-2_arm64.deb
     digest: c55790b3f227a9f9b3736f40c03c8881adcf60732ce7be9a04c7b79fed7240e4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_arm64.deb
     digest: d989b877a836aa9d00d3d211dec9ecdbd06a1a18bd5683f154ad12c42f8b5bff
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libsodium/libsodium23_1.0.18-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libsodium/libsodium23_1.0.18-1_arm64.deb
     digest: ed58a5ca7a8a4646f503396064852c8a1ec2da9a377a0626deedd2536172fced
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
     digest: ffeba610e1f0ffa299499d88562b65eece4f9865d8810d3a6194ff5d2cd02b38
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_arm64.deb
     digest: bae9a1c57122e44c7a58b3c3572049080ab0a7546ffeb141b0ab81eaf0fdb698
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_arm64.deb
     digest: 359f8bef6d4a77cd5875d210c50dad400ba3cb6625929fc9fbfa5d56d6027a02
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libssh/libssh-4_0.11.3-1_arm64.deb
-    digest: d5067b78f7cd1d9bb9fcc22e5a1184c8d39159712cb14797937dfc13921f47d7
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libssh/libssh-4_0.11.3-1deepin2_arm64.deb
+    digest: 2b7a7ab3fa0107a1a4d5ef5a3e686e2fb711527335e6a6712d9cb5abcbf7a92f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
     digest: 6afa3a2ae947564d05b220d89298c7e6e1f875cb05b4ed1a9a450be99a3ba47d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin9_arm64.deb
-    digest: 68558cbf05495c0a1c678ea936983a90a2040d51311bd04a6bfbc9a73c45f3ae
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/ffmpeg/libswscale7_6.1.5-0deepin3_arm64.deb
+    digest: 36605de69abc470386fac7be8305812deee0cf4f3a3529fd0d7d8f15f5ce7acf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
     digest: 41ff44785effab7f081c3d4744d9e9cf25e374c13a00ab8ef93052a0a4d57114
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
     digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tiff/libtiff-dev_4.7.1-1deepin1_arm64.deb
-    digest: 641cff4491bfd45d04124954e1d142416ffc038f5be0765b7b6a2e2228fec983
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tiff/libtiff-dev_4.7.1-2_arm64.deb
+    digest: 9f2574a0eb684272173704bc9a493c6493a46e5feea1edaa8f6e0e42e0199276
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tiff/libtiffxx6_4.7.1-1deepin1_arm64.deb
-    digest: 034986d3a37a5e59fc1cb0e41b0fa1141ed76c0acff3d09bcacaa268f109f034
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tiff/libtiffxx6_4.7.1-2_arm64.deb
+    digest: da29adb39d8d4040605d05d991e2804d49c359f65949e05cc281ed1f614ab50f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_arm64.deb
     digest: 48481125d3ebb3c27907cc158518e7d3bc25c7c527589b08e7cfb56427a04f9e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
     digest: 790a0e469c3b174d03eb0eb64f4a69ddddd95ddfd4b8daf930e4b4ac7cde179b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/systemd/libudev-dev_255.2-4deepin25_arm64.deb
-    digest: d72c8c88e272157752f6e206d4fd8787dadeae773c8cdb3b36860b175000accd
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/systemd/libudev-dev_255.2-4deepin31_arm64.deb
+    digest: 9a9b8ecd38fa397ce5603708a266dac68cc3a244a6ade52d4371ce6a3e33b495
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libu/libudfread/libudfread0_1.1.2-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libu/libudfread/libudfread0_1.1.2-1_arm64.deb
     digest: 4e25fbdfe08288e6f58cbf5a02a5147f4c2d6f41927020d20cc1a60ce49b5c0c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_arm64.deb
     digest: 03f79776d79c5798181a5c7cbeec4c2af9971b4956e9a574b3d4ea07c742c0a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_arm64.deb
     digest: 1efd5f219b0440fda1a5c2a1b4e05148504576b710f18c374908843d307ac93d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwacom/libwacom-dev_1.12-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwacom/libwacom-dev_1.12-1_arm64.deb
     digest: 3d5a7ebd49f242956b1058290b1a909c4b5e687529d3b4e8530c1556f3d99b40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwacom/libwacom2_1.12-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwacom/libwacom2_1.12-1_arm64.deb
     digest: c07692f2fda707855dbdd2f4586f8f1acf5b9cfc9618db7c08bf3442e4b7af3a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/w/wayland/libwayland-bin_1.23.1-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/w/wayland/libwayland-bin_1.23.1-3_arm64.deb
     digest: 3322bf5f004c10b95c312e95ae90c1bb6bb7b3595caee178d7d02d79397f50ed
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/w/wayland/libwayland-dev_1.23.1-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/w/wayland/libwayland-dev_1.23.1-3_arm64.deb
     digest: d845dfce94123d2388750b820ad1299ac542aae445a29a7aefff300469d88ede
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_arm64.deb
     digest: f783e2d15596e657a9077db7a3dd7e8de84360a27ab504644069df49922a9545
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_arm64.deb
     digest: 9115ed02a3d0d9de956bc1474b608f922aa61feecfd27e267d88e2687caa19b1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libx11/libx11-dev_1.8.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libx11/libx11-dev_1.8.7-1_arm64.deb
     digest: 1c6d4a10271b55eaf39aa83f76851047669a842f2c15b18282f2851bf29644d0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxau/libxau-dev_1.0.9-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxau/libxau-dev_1.0.9-1_arm64.deb
     digest: 28ba4c91230a4d8e3caa43b0897bc56960e5b07eb6e8297ddfe3d57c3514457e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxcb/libxcb1-dev_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxcb/libxcb1-dev_1.15-1_arm64.deb
     digest: f655f75fb5205cb90667bd2e1b1c08ccd93e0f937d1b4124b10afbab5bd4bc54
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_arm64.deb
     digest: 114d2eb11180679b69a9b8727e952f40be5cdfc0ad878d632e727d7b1d5d81d2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_arm64.deb
     digest: 941544912030ac7a4ef2b1c3944932245be753179c8b83f93f2ecce2286ad833
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/z/zeromq3/libzmq5_4.3.5-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/z/zeromq3/libzmq5_4.3.5-1_arm64.deb
     digest: d0604b09daeb5a092bc3b7d77625f48456e3b5a5a3fb660122d36107e8a14ec3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_arm64.deb
     digest: ca9575f6503945c733c4dc2ce78dee09745bdb6eef34f631212d2311e1d635f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
     digest: 68e19fc7f99e8c9d95a0ce2fdde2af187302ab9421cdfe7913d66a8502fa128f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/lsb/lsb-base_11.6_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/lsb/lsb-base_11.6_all.deb
     digest: f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_arm64.deb
     digest: 0e32f0eef7e7f5effe89929ad9a1c14a2838e5033fa9142cf0b3e6bcb81f8573
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/make-dfsg/make_4.4.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/make-dfsg/make_4.4.1-1_arm64.deb
     digest: fd601544bf60cf407d143282c4fb1296842e0cb583308339bde436df40c45b36
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
     digest: 848333f2b40b586ecf8f0db2b6127398d0423867e689937c4427ab15570e5581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
     digest: 729d9b051d2dcda0d0bf51fee21d3b685093314a0b2283926f1eb11f937cb04c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/patch/patch_2.8-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/patch/patch_2.8-2_arm64.deb
     digest: fcc3a3467e4d443f164f0f2ce59e51f546ac2f8d82d0de6fa03e9f942577d144
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_arm64.deb
     digest: 5fd48825ebc6f224e26bc11402982b6767d8a87b1b20bc28ee7dd4106534a52f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pkgconf/pkgconf_2.5.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pkgconf/pkgconf_2.5.1-4_arm64.deb
     digest: b926d80339b80dd7dfab3ed2b9629f1c95c7432379f74eb1db625b1c78c371aa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
     digest: 4b0fffc886401daa9acfb53e2b190528e3fad37a49b989c4fae6715004fda41e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
     digest: dc2acf26739fa1e49d3961179086bf8cc99a18daea02fc75e41a6a954a75da35
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 13404fe6af13a6023f81a8c1d95268adc19c90ae96203195330cbe029e06a168
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 1c0acb5918b34c8d3c84e609b6011aa4c7149dc1303da8e759436f6690673373
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 0c5f3c2a4e3125f019952f6d9a8d0ea594e2e33674981b7e9c60d1787cddb20c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin12_arm64.deb
     digest: cd7fc66b30c09aa1ade067e62f643e1b39efa7e5153328f02817ddffe67ce089
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 9203b8ecb34bf02fbf34bdb4591b5554056cd36bdbd9499609d2b79c1ec84a29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin12_arm64.deb
     digest: c7664219ac9ccdc55d22fe89ce1562fb8873786e11e9e0b4d946eaa4c9e424f9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 7bf25611e423dbb9c6a35bf5ee9f3ff870d282fe82c1a65331bc4913de1665db
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin12_arm64.deb
     digest: f5b44d9fd0249a759239587c232bd507555d5c1ce94fd4cbf91930e85351207c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin12_arm64.deb
     digest: fe4470bc75fcfd2094027360acf5916134e5c3941f56a0e8780b4ac69644c56d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 6037742eaf03a013f34ef7baef995cdb09538f41f4d20c2754fb6fc8528f23bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 49414749476592b508786ebf72671748550982d36188580f83da1d12626ba4e9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_arm64.deb
     digest: 0a4a4e7f77ba792604bb9563b61689c8311a746bc4d5e2c1a10b80fbd9f91785
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin12_arm64.deb
     digest: d5330f9fba84ce75c52ef5bce97b780361f5c05bb70b5ef976c75f6729d0b1a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_arm64.deb
     digest: 18ab6b266e8492e2203479d773b546a203188b718178a69208d4c213be9fdc91
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_arm64.deb
     digest: 0165c450a2abf4ec099df4a3e7e5d1cd253fb3ebef7f23d8a28a95763f14e480
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 974fa0d0024f90fb84e21377e4d14756b4a5685eb85419166e16b820c0b89407
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 188357511423951b48157cc69834b911ebfeb15315395ae7e69a2469b6ffa212
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 53af3e39a39dd9e9b59268e7ea9361f2bbf6e51f7a4f04f91eca8bc6f0657853
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin12_arm64.deb
     digest: c75aa34c74cd1e3dc42c6588a6bb7a3b419fd98f9d0998a33ab041d35f71cd47
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.44.1_arm64.deb
-    digest: 62ff0f2d8187ce3d50726027d30a60c75cf217580eb2d9c0ef12e6971c4adfd6
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.45-1_arm64.deb
+    digest: 853926aeeb641a99ea18aca439bb4c3349ea16fcca4cb7e6b0652dddc7bc1129
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 908ba2c24f45562db2f9b58ba4e1ae8cd09a0cfd4d515c7ca9768a64a4cb40db
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 7fea1632e581ccaf8652d57328cfe12b2ac5cd95d9b3acdc0dd679279620327b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 536def60be7c7d3b47e43b82e3d0cc675ed1ae56cb418c59c7fbe14bb07de77c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 8351813dc776401d807f8f2ef378079c4a3d49116b2675ce135772cda80f9aa5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 7398585c9af340f4b315aac22e8b8e6c10e24973fb41363758c8eaff3765879f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 68790b25b2ad40c49c0b247520b65a6cd0a191138a50ee019d5c8977c042c6eb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 76c3b49642d02ea83f15f5d80f3214e3d3d5e24f2159fafa27151325d3020f52
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin12_arm64.deb
     digest: d622ed6d52607c0de2bd63beedde67e1753f248ff45cb58eda1c677189b5eb5c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 7471822c2d389f063e3f81bf8176609b21af54749938b74f284f8b5d61bd3853
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin12_arm64.deb
     digest: a5710c3bd6f92c751bc3e99d22d38bd607fc64e048cd37f9944492bcdeb0b2c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 0c1d8388de42955af72dd0f48d978482d6d673631817b9c1570b659c2fedd484
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_arm64.deb
     digest: 18c3716aa0b734ca7d22e0ba8e51df49ad55c2c76726ee1e4a638007e3044e60
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin12_arm64.deb
     digest: b24ff135e87ce96627a06c4188e198abf8aa2de3179e884561a9594be621ee73
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin12_arm64.deb
     digest: ed1d0b35465b0ff2dc0d993da63af0ad9b87470df88238ce9c41570f901ca895
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_arm64.deb
     digest: 9b681bb49432f5a20b98ad7939c4102975f5952efc7dc7ef1058d3ff7a0417bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin10_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin10_arm64.deb
     digest: 94a7ad0a339b649e7a09a4063542f6aed53f6e7972596d886286c6c4257703ce
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin10_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin10_arm64.deb
     digest: 5c4ccb81416fd012572562255fec6c27a9a647279ec601c1e405e5be7f3561d6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 44d158a606769e6d8e9040dc813219c6e27ee93d25bc321ab14d147b26c7ee9d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_arm64.deb
     digest: f16c25091859915e16ec9079cf2e640f789fd896b55aa43c4a2b00d7df88c864
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 468d158cd804c1c17ec7b1085531ccd9a14312c034c3d8db9149d86789c5eca0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 05426a825f7929c9f89b7880fba4e3ba50d50b3255442f3d907837652d768cdf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin24_arm64.deb
     digest: c49f0e76f6ac767891a195d56dca40e96afb1480ea0eed90ae3ebf2397a1fadd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin12_arm64.deb
     digest: a65b21e7c7440131883b338775aaeaae4d595f616e349af1f23e58b7583120b3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin12_arm64.deb
     digest: f6015e8c3774de1741ab9247b1841c36565203a8073a37251c914bae9f71bda4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 361e0049895e9e2722915f0116c267a8d85f62e51ae5110e5fb34163be5d32dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
     digest: 7240dfd58e097adaa152de41b86457f9933cab56d919b7fbaffa783da48ddc4a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin24_arm64.deb
     digest: 00d63bed2326959d362aeaff0aa176fa0d03824a33b1e5bf6483ce53534b313b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_arm64.deb
     digest: f5599ff2546d1f99133d853e039e11193f45e5654f2bcb835e26218b52dd15e9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
     digest: b726420f3a1803c2d33e714cd29b9eb757aef9a607a42d4d9a4257331d30b4c2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_arm64.deb
     digest: d024d7f1dc80124397a3d4a41f4d2015cc72819d7933c0e5ac1cc2331b1ae548
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin12_arm64.deb
     digest: b514cbf95ecf7ebb09cb51f142aac148ddecc6808c870f033281a25a6360c585
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin12_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin12_arm64.deb
     digest: 12283b6eb1c5f7f4b13197fcc850d587b5d265a7c6b5bcf1dd005d44c1730763
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin24_arm64.deb
     digest: b1b2cce7ed9bdd2f97efd6acdc1112a2f04518c495af5f969b6eeeb1d7ab3815
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_arm64.deb
     digest: b9cff1d9eac542c46a108dd15a20163fdc53abe14fcf21f6be90f98bd14f8127
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_arm64.deb
     digest: 3815c4d7c65d592eb364070ff3e8aeb1e5e1977e3652d5f266bb02cabcae0f87
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_arm64.deb
     digest: 096625f80d868ea9fa76a664ec8d0b821d696e6ed0599be4f3c23e94e1f5b9bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_arm64.deb
     digest: e1c490bdcffce0b664685edc6d97151e7aff8018c3cadd8f1583fa6fa20228cc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_arm64.deb
     digest: bc8717ff810872db3809ad67690c5359656b1780dc410c78c82d69cf3c19c711
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_arm64.deb
     digest: 841e0c1addd40a42a1013e897162d217c27415ea2dd1ebcaed7b61b5de1c8944
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_arm64.deb
     digest: 041a22c18eab9afce1af06a67a4e535ff870edd5404601c75fecdf091120ff95
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_arm64.deb
     digest: a6351936c0c2deeeb6fb3655429b0fa42b24c6d59b7f145f7d19ca7032b1bb68
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
     digest: dbfa88dae0e66fa60e6558fa80242bb78be8dec5b37ea449f85826b1b48cf25c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin10_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin10_arm64.deb
     digest: ba0e6893cf44dcbc4986fb5ffc011e3c482fa22e9cba44ec60658c626fd77fb1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin10_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin10_arm64.deb
     digest: 762b288700677582bc166c89e9db4f8ad72e37507156c85231c7071e1e556ebe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin10_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin10_arm64.deb
     digest: 834fb795e033990e6141644747a98a8109ee9ec65b3ccf64c5fd89bf5813440c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin10_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin10_arm64.deb
     digest: 5ab3062cfcbfca2564bb58ef9dd9eaf34b9727738de42466d2acf3cb70a9097b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
     digest: e70bbe5b35aa1009f8d3e8d58634052977864bad1d854230add6758ef238b1bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin24_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin24_arm64.deb
     digest: a5564f1caa4ad9557c541539ef854f26c67c388bea3b78cde1bdfaf0de6c2834
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
     digest: aae8ac2b6d3198d297d430cdb97e556365be2ff46d06525008ce071d97ac69c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/uos-license-content/uos-license-content_2.0.7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/uos-license-content/uos-license-content_2.0.7_arm64.deb
     digest: 336dca2068ac0e9a47cdd3ef494eaa9cb0066a31b19322c22e90e02362edf93b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_arm64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_arm64.deb
     digest: 425f15ff8656cbf9312b2fa0f18c4cf77855c0d0955db4515c0406ce801ff6d1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
-    digest: 29a1888f6b7be54992868b36050c68d6063820ae6c4a2e09ffa2317a7e0b6d6f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.2-1deepin2_arm64.deb
+    digest: a15a6c76aced4b69e51f7d6fa0202e67fc8577cd0d1f915420c991405b684e97

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -1,10 +1,10 @@
-version: "1"
+version: 6.7.0.45
 
 package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 6.7.0.44
+  version: 
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -13,7 +13,7 @@ build: |
   bash -e build.bash
 
 sources:
-  # linglong:gen_deb_source sources amd64 http://10.20.64.92:8080/crimson_runtime/stable_20260708 stable main
+  # linglong:gen_deb_source sources amd64 http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3 stable main
   # source package qt6-base
   # linglong:gen_deb_source install libqt6concurrent6
   # linglong:gen_deb_source install libqt6core6
@@ -179,815 +179,815 @@ sources:
   # source package uos-license-content
   # linglong:gen_deb_source install uos-license-content
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_amd64.deb
     digest: 8b5df0b28f8a7cfc63a1ba4ac369f09a66e19d47a462c4bc8fa8bc552f18a714
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dbus-broker/dbus-broker_29-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dbus-broker/dbus-broker_29-3_amd64.deb
     digest: 68ff1baedb2f4ced1ff5d2f9c3e59bd21e741b7710931e0539c89ef5951df8ba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt5integration/dde-qt6integration_6.7.44_amd64.deb
-    digest: b72adf2866dd0b813eadfdaee609b0b95230beacff8693f6e362e1881f6c704b
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt5integration/dde-qt6integration_6.7.45-1_amd64.deb
+    digest: e457d2a0b9da30a9fbc697eb772cf5a64791d146ff9b1d3f79e52e94957821d2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.44_amd64.deb
-    digest: 0da7d27bbe04335fced15cb15865d547f59f2bd5b9ad7a77f774a21f331fa3b0
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.45-1_amd64.deb
+    digest: 190c2543afce8c4b9a35d747c6451bf8a270d914a7532ef79b97890ce672f4dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_amd64.deb
     digest: 8502f9dda05684b5114e9497d55e057aa3911f5b03e27db317a211f4bc3389fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
     digest: ec9d003e1996d9dd70c29c8b1d1ecbb0df0523cb64eb617e2e958fe59ef3110a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
     digest: ad27e359a1fe3485255ce3c17eab99ae42ce1aa03acd67e45a2751710dc463c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.44.1_amd64.deb
-    digest: 329d3712317874c44e812c4cb96023b9e681b617b7ab79b002fd59168a952a16
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.45-1_amd64.deb
+    digest: 6081a939785e81af48b495d85c91710c9b0d0e24b4d99a4cd2ea4daecf82d86e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.9-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.9-1_amd64.deb
     digest: 50d88ef6e58dfdfaa8dce68cfbde3823524bf9e38bb906d68705738feb12baf6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
     digest: fafd08c872d1279aa0bde2e0bdf40a57721961934c0593352b6a2c551aa232a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
     digest: ef932bad267f9d4d49c0c376ae1d0fc1a9b595054f8450d42b2a0d6621bc7084
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_amd64.deb
     digest: 3deeaae0728e06b5746cab0b8f621986d6355ec09ca1130719c7be1900b1171b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin9_amd64.deb
-    digest: d70bb3bf85bfae53dcd17b52fa75a612400debe0c18564026d41e5c1c143dcc1
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/ffmpeg/libavformat60_6.1.5-0deepin3_amd64.deb
+    digest: 1ffd35eb7364c1b7c360db8e7a75663b36b005bdd3154e79ab184a61d0f19fc4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
     digest: ad82b2de93cc49cdf37c861b03275245318b1555255639e5e805cf612a40171e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_amd64.deb
     digest: 9b9bd06169d7b6d031810f25f45a734052ebecab866a88ed1b2610fccf2fd739
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_amd64.deb
     digest: 563f4d3b275996192a906b926390435bb3e444294f8766b8db5ba66f199db55d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/b/brotli/libbrotli-dev_1.1.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/b/brotli/libbrotli-dev_1.1.0-2_amd64.deb
     digest: 87226cff96c560b3ea8b15110f7f2b00047b0cc9dd29c9fdbc372b4d9154de80
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_amd64.deb
     digest: 60e1d9cbac4fafa4f7823e6495212ec02805997e64dead0f40de1d86ff138d41
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/capstone/libcapstone5_5.0.3-1_amd64.deb
-    digest: 0e6b1c94b28127dbb067f7ded642625abd26fac8bce528aa9bad37e5b66836f8
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/capstone/libcapstone5_5.0.3-1deepin1_amd64.deb
+    digest: 6db3579d187130f77651200eedb97e0c8aad4b081770c4ac68f3ab2d3570efef
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_amd64.deb
     digest: 1ee2dbafa2c331d58cf10cdf546c760d7a734c5d9fab1b16d2e04e51f6e38623
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_amd64.deb
     digest: 0c0ac88efe846e4cccd84c896722e981be3a276b984541a4aeb67b1a97a86100
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_amd64.deb
     digest: 88e484221866f3b51022b4e8dcd3d4a2f156e2de8118603f266d90aacaecb759
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_amd64.deb
     digest: 5816b1f4f5a5f2cce5737ea3c39525189212f4fcc955e4f2e3c5ad26d887964c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_amd64.deb
     digest: db9bca0c6cc68db2c0f31712b94c36746307cc99a1f8a7e55a02c0d3c1ccea40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_amd64.deb
     digest: e46088a05f1b65f8ea777dd2b739c8dff9e37606b16ad047fdda36642dc4bc58
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_amd64.deb
     digest: 07722256ffc3605844dc08530aca547143771af140f142896fcecd90bcd83655
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
     digest: e6c6d028a74d0a752ae638ec19b8239f404c36d676c7569936f31000d25a75f4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
     digest: 5ac1e65112a190dfca99abf002e3e3f0ee033919b7b65cef5e3637ff1821cc9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcore/libdtk6core-bin_6.7.44_amd64.deb
-    digest: 20115a794fbeb628e0bd064ef8cfc460e8bf67a081d74db3a6e80c1f9fb783ce
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcore/libdtk6core-bin_6.7.45-1_amd64.deb
+    digest: 289e760079d8543440691055482f5f3133c4bcb98142a8cd9817d308b5e305b3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcore/libdtk6core-dev_6.7.44_amd64.deb
-    digest: 8d1ac95cafc556ae77d4e2633f6871d536aca99e4db41a8d5c688cb140123618
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcore/libdtk6core-dev_6.7.45-1_amd64.deb
+    digest: eed25c9307bb7dbec93982c3346da7890ec030f614f754f83d8d24f11124551b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcore/libdtk6core_6.7.44_amd64.deb
-    digest: e331f10a04ff87caa6098c7708aa97d6a1a328b474abe43ad83d18d129b9b7a6
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcore/libdtk6core_6.7.45-1_amd64.deb
+    digest: 6c0ac002048ca1462ec6e25a9a465ac71eea9a5e9dc37daceded428a31019364
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.44.1_amd64.deb
-    digest: e7ec059d61885bec9c471b983f5925fb5c08caebd72649a016f1f76d51259be3
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.45-1_amd64.deb
+    digest: de8480f1bc112079b0636a84a534942ac3f8aa446e61adef51297fd8bf33b8c6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.44.1_amd64.deb
-    digest: 5358d43cc5586b9820f46a8af67f8821c54dce40c14ae9f0b5fb7333ac5cfd7d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.45-1_amd64.deb
+    digest: 3ed3587fa115bd37f1772e6c8c1df8b358bfddd7e71357d44662aa297b9a69b1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkgui/libdtk6gui-bin_6.7.44_amd64.deb
-    digest: 25ea4edc7808c79573abca2ff0ba0f13c915c02b9dfa9df5a5a80bc75da4d117
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkgui/libdtk6gui-bin_6.7.45-1_amd64.deb
+    digest: 7c6fb2284be66d995ad651b90e4d5802080c4c8044ca9d1317d9b9f42539e335
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkgui/libdtk6gui-dev_6.7.44_amd64.deb
-    digest: cb485f7980f92580d88ebbff8891a3b5e1b6ec93f9765eecc0b16c27783c711d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkgui/libdtk6gui-dev_6.7.45-1_amd64.deb
+    digest: ce505726ef1a966c2f6ec820f003480ad5fcbb339019acb8699b6d4b8d9c3a40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkgui/libdtk6gui_6.7.44_amd64.deb
-    digest: a569993659a0b623c1f4b93861c628366f96cba726ba57aac2ce6d0a7893fdb5
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkgui/libdtk6gui_6.7.45-1_amd64.deb
+    digest: 3c6a0a6d2d3188b17c03b3ea723b28d378c528f733b9f7f2047aaaad61ca1dd6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtklog/libdtk6log-dev_6.7.44_amd64.deb
-    digest: 0d94ae3458fd93ee8c848f6c23702c7c7f5471232d7f56334106a217d84e670c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtklog/libdtk6log-dev_6.7.45-1_amd64.deb
+    digest: 9a35ac621bf5d0e59a895b0881fb59e3dc3f212b70e57000bc3452890ac82b6d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtklog/libdtk6log_6.7.44_amd64.deb
-    digest: 2d405428a8f20fd12f45c224b76ab80f363251f33b63c39e46be88746b592774
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtklog/libdtk6log_6.7.45-1_amd64.deb
+    digest: 8426f3a25c7defd54b7e9a6dbecd25459114968d7a2f4b5e6ed174a4db102e79
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.44_amd64.deb
-    digest: 58574ec7143786c89ceccb1fe1dd35f9d90ed9fdd38586d35b22b7e73d1bcd23
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.45-1_amd64.deb
+    digest: d6940d58a2312bcc9f422d969685c1aa31766391e60f231d12a33665c636931a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.44_amd64.deb
-    digest: 35423867de3aa8516d33b071110fb6f70d27020ffc33ad8dabdfa081d305e621
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.45-1_amd64.deb
+    digest: e30386938adfca86fe89327d08e26354edf769a7bdf242ec223e89e76460af46
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkwidget/libdtk6widget_6.7.44_amd64.deb
-    digest: aae17de27ab3bbd381cc7522b18fc56925777692b0a37164b54eddb051e77976
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkwidget/libdtk6widget_6.7.45-1_amd64.deb
+    digest: bbad1ff7cead85591f3789ceec58baf104ad69ebf23c3e71d05623dad2f0b942
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.44_amd64.deb
-    digest: faaf05232211e3f0fb3e8ffec5f0abc50f596e846194698eb82ce3def239fe60
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.45-1_amd64.deb
+    digest: 49d6d03d4ba4cc918d7e1b853a94de24d16fa93b401db02c2cd333352d14cb98
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcommon/libdtkdata_6.7.44_amd64.deb
-    digest: eec45a0861b66a52fdca8cacd2770998487ae1615992c3abc33352d4a28dad6f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcommon/libdtkdata_6.7.45-1_amd64.deb
+    digest: ac9c50f065ae6e814d7edbdeb4c2d63d5286217ea24e6bd1aa9cf41c1fb30872
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_amd64.deb
     digest: 97ad0dfcf56a9bbd5a2e768603d686cd1fafb9164584bd1662fd95b49d0a9c4c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_amd64.deb
     digest: 5d6b39df3bfafd42d3de1d445c13f5fc4de2a4c772b4e7a2663bd4af573a3870
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/e/expat/libexpat1-dev_2.7.4-1_amd64.deb
-    digest: c32c7230aa02e0b140e90339b660525e7ecd1aa2d9d52b968353f48e5fb63b42
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/e/expat/libexpat1-dev_2.8.0-2_amd64.deb
+    digest: da8d21db4d6c6d3021fe01860188b79ed70bd01abda2a1441cd22d36f6c47488
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_amd64.deb
     digest: 69c8f541c96059330b8b59f110fc1501594f72c291585c04997795f0b24ba105
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.9-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.9-1_all.deb
     digest: 095f6c357e994b15d51e9cf85722cbdf80f821a8ba2e5b2310fb9a40bb2529b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.9-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.9-1_amd64.deb
     digest: 47c84bb370af22a679d2a7dc065cb06516a830aef28fdea3cd9c244d355d0b8d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.9-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.9-1_amd64.deb
     digest: fc68138bd7077daf6b8bab0dce69a8abddfa6b8b62bb24c29010e361ffde80e9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin1_amd64.deb
-    digest: 32a383e376ed59cb776cd7df67a8f0d0534cb236c00461818d177aa920dacb02
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin6_amd64.deb
+    digest: a6d50b000fb897cea26ce9d563074058ba14618b687f68af7f31270d5a3f190b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
     digest: eadc61825e77bad028fd5eff398ac0e13da7a08870261058525d3f620d90cb7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/flite/libflite1_2.2-7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/flite/libflite1_2.2-7_amd64.deb
     digest: 8851ce503276f63416a9f1776fe8051b87c2fafcb3ed0990bd4e1572b4ad3ec8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_amd64.deb
     digest: 00a674b9b4c7034dbda109a463cfc89e67f803b2fba83965992754a79e948fb2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_amd64.deb
     digest: c43e1ec347d6fa3a1c42b273f9fdd736996f043e4a24dee4be0516c05926321a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_amd64.deb
     digest: 006a8d5b94347c80f13475dfc3fef138932400a38bd54f5dc762758f30e0cddd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_amd64.deb
     digest: 85582a97b11296a1012fbc5df9aca47131b1c799aed5069124bbda1269adb13f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_amd64.deb
     digest: 9555387119d2c7118202da7424f3d95a358843cb6e3369135979bf3fb1e7586e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_amd64.deb
     digest: 21242e99b2d8615b9c24401c65525603670744aca8c2ba08d9621ea8dccd07a0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_amd64.deb
     digest: ac3c1fd8eb08e6be3a3cb14b8ac8ee33c233bcf5b0900e48026e8fd2c53ab54b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_amd64.deb
     digest: 5b8281d799f1b3844524c1baa475e4876665b4d6062800655e180586dc0015bf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_amd64.deb
     digest: 6f185c6ac2987d5d8ac0f81be7f0377ac34c00ba45ba8d206ae7ef5888bbca00
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_amd64.deb
     digest: dee4a03abaafa64f9c5c85b107d603f78957506a58f5a3d7a9ca50654cc9742e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libgudev/libgudev-1.0-0_238-6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libgudev/libgudev-1.0-0_238-6_amd64.deb
     digest: 562fb1c4a945754f1a134aaff3d718533d8b91537862397c23fcdfdce30b13cf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_amd64.deb
     digest: 056919a20ff7d1c9c018efddbc7c568c5362f439d371aebd7838eb89ea0ccc0b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_amd64.deb
     digest: b4036cefbbc4f6a5f73f6ac19d3065c52dc6b923691268c5b3032971465c35ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_amd64.deb
     digest: 053103d5bb15e093e098dff38967470132d0d2ac700282dac521965d61d63c37
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_amd64.deb
     digest: f960b005d701ef23c211a2b5d07708669114b4da523cd3d4996037ddbc931121
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_amd64.deb
     digest: 41620db50b4f194759575e4b069c4bdc7f788e5a8e3a620d00345706fb01eb55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_amd64.deb
     digest: 7ce8d535aa0768ca1cf24178b956b3bbbc82cca19ce4bbe91ab32c36038ae336
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_amd64.deb
     digest: fbc596effd2b0a596b71e306d120e5b660bd478c8c9d24e47c61b4ce2db33d27
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_amd64.deb
     digest: 126fa110768ecfbb4569ddb66d53621f7007dcefa1234e0ba4f37e364903a607
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_amd64.deb
     digest: 9bf199c57795a3e4c8e7cce1ef1803e32e9d31fc7cb82b5db8275f654e19b655
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_amd64.deb
     digest: 44596cdf0fefdc6412af3e1e0d0a4bdee4762d348cdf3818a2cca0daab437285
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_amd64.deb
     digest: 0e611c43cc8cee4b31dd530ef21f4efbb16caab257685a770b612146e18a6b8b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_amd64.deb
     digest: a81ad1bcbf76123a98aca07e8bb02b9e21a592dfdc7513810335c18b471424b4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_amd64.deb
     digest: 3e6e0b346583febf9b616ea25c183c85f4821335a94f9cfd1d51011ec00ff3cc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/md4c/libmd4c0_0.4.8-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/md4c/libmd4c0_0.4.8-1_amd64.deb
     digest: 9f1630409adb3464aa42afc519d2163a7741d152b53c937eddea55b9fb6fb10a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_amd64.deb
     digest: 256423c8e3c4afcbdf72973db84b1e919187b65955c685ee16f9a5635d436943
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_amd64.deb
     digest: 4032c2da0fabf1e0cbe6f7adec0e62a4cd0dafd11aee37ee3d2832b645ad733a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_amd64.deb
     digest: 92553337dcd1837205a4f136419b0cf40956e0975a938ad8e8e7b586659d0e46
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mtdev/libmtdev1_1.1.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mtdev/libmtdev1_1.1.6-1_amd64.deb
     digest: 28686d830a44272e63013aae1e508f0f767ea28c2a4856d6c6724e11b2a6f93e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_amd64.deb
     digest: 5b552cdd40095bd94c6276021dfc5360f2a6289aa94f155ab3ab3daaef341c1d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
     digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_amd64.deb
     digest: f38475bd848c5e0f4481bb11a55779bcf37d263523f5b7a7625511e7202236b0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_amd64.deb
     digest: 178ad33f72e1905c6d777a680fad42295608be7a6f8f95dfe5f2f27dbfcd5505
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_amd64.deb
     digest: a037354a8429c3c32358ee745ab5dfe3d92cc60b74fa68d6355e8b63ce100fcc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pcre2/libpcre2-32-0_10.46-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pcre2/libpcre2-32-0_10.46-1_amd64.deb
     digest: 97811098f7fc09c7cf0f3e1b5bdd9812af8aa5793039e8b678bfeb8d57b9750d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pcre2/libpcre2-dev_10.46-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pcre2/libpcre2-dev_10.46-1_amd64.deb
     digest: f1850c35ce5b42ad77153650ea66f8611b2c171b5b8761870f938795f517920f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pcre2/libpcre2-posix3_10.46-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pcre2/libpcre2-posix3_10.46-1_amd64.deb
     digest: d4e0f487adebdfeb320945153d10ec21f094eb4aea3c806db768ab89f8da86eb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_amd64.deb
     digest: b8f9b921c681e6c08abd8d452489762dc8ec3234e058407757f4f383ba2a01c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_amd64.deb
     digest: 9faa99ec2ae5dc678bde09299b6dde1c7eb5c5ebc27039abad8a626948119b7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_amd64.deb
     digest: 774b3b62c14cb57fecd209006fb73282903f14b8a322e9ed6be0b7b6645def2f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/postgresql-16/libpq5_16.3-1_amd64.deb
-    digest: f458fa7e81f3f405b122df4a87d65d93446476b0e60da81ea8062235513df9eb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/postgresql-16/libpq5_16.4-3deepin1_amd64.deb
+    digest: 7044bf468fa3f90fdb4598c5286e0587595353d6f6053c6cbbf06a8738933136
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
     digest: 8be922fba920a96d098288da4fa5f1d5dfb778b362d7a26ed738014305aa3787
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 4b97e734cf6c27d882af2728aa333d3f849ada9bb2f27f844670338864f744d1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_amd64.deb
     digest: ab7b2830d58cf362c4f33c7252a7ffe5130893560082eb6a43a9d208e4407e84
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 5e231f66c9b2c40552f5b4e42d0f02e096df7535facec9cc13a0aa253d649932
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: c7c0bb6fa84ed913a95b0be0ae5f4b1021fc1f5bdd337c4e5276a5e94a06767b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
     digest: fca05a0b5e2a9e79d70fb282e4fd5be1d8c0e5218bb359e5985c47a3d886905b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
     digest: a7cdf3370adfc03459761b96ea0701a32374981e41d875338cf21f68e32e31fb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: a687d47aa392b8d89fb3a5d3686087edec6e3831202382a4b56c31f9b0c9a188
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
     digest: 1c3db1f054f82d7c0957edb0e59a084a81a7c3df5c43357f479accbf9df075e5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_amd64.deb
     digest: dbc187ef7ae9fc30a2880002a2cc4bfa132f83dc7c2abff91b480bec6a8fd187
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_amd64.deb
     digest: d754dd297c4bd2b2a93ef7d7bec5b1929a8f06a6b35ded515e01331633d1204d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 47483ae70337322db3e744d0568b9f8b40b4f825a2015d64db00dfe64787ed16
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: fd536ce9201ad1af7483371adbfeb2c7f018639b416d96b443d9aa6d09eb4c4c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 702dac02bcbffa3c761605bf08e721e8c4282b9a432274cab90ee3b50abfc3de
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 57bfb3aff34007e40a74e0431a743951c3ef6fcbed7e9b4d54f32416438d5d6a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 075c8917a74c5f0b866ea5c35c5cec7f9154cc788274174ddf3aec7988b0c867
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin12_amd64.deb
     digest: ccbfc8c5645c996d1401660db7b97cd8dea9a7b7b17bb25334394a6e653ea82b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin12_amd64.deb
     digest: cd3f17573b711bd7c90315d71f38903af2750b76d3aec77811b843c8852676a6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_amd64.deb
     digest: 824c7f5ea18c56c178f06c891eb718c939fc0a4d387dc55c048b4b234a21017c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_amd64.deb
     digest: 48df47dc9dab619440be10b81db1a6d75c4e86a6f0b74b98f3d92f6cf97f3894
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_amd64.deb
     digest: ae1f26a30324396caf7f9b2bfe6194610e91d719d9a2b2d53be96426ebb553ef
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin12_amd64.deb
     digest: a750eaf4fa120c3c04bdfa034c9cec3cdd270faabcf4ef90978fd5df23580d32
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin12_amd64.deb
     digest: e083b215f9e9726c7b84513a86f984470de1a104a0a3394df623d9274404d293
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 98359532ec5a217c8a5a140bc02fd3bc5eb7efa51a03155ff2ef97b14610ca6c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin12_amd64.deb
     digest: c282b5d6a4f4897b2475618493d657ff30e6f28a09969d76393e174496da5545
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 537843bad365af770073f4880e2dd3094a1c86258717e252f17577774c27cbbc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin12_amd64.deb
     digest: da8f5e212178b02e033181bd547ded4a172d801b14740a885f3ca166345bf292
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 0b8e8bde537f888fe248e2d54830bb95375301c54b350ab17f77b2dfe7bf608a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_amd64.deb
-    digest: 4e5dc0e41f8c49451b4595e605ddbe74d5cb4fca3100d26b552aa6a0931d575c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin2_amd64.deb
+    digest: 49a7c22ef19dd7aa650742c226c32a2f52b80b6501e96e79fecd09c108c5eebe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_amd64.deb
     digest: 73c0e26ebd541bd02158cf6265fcc55b16b7148f9db0a4130b7d7bb50a83978a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 71a2bcd8670184bfa38791bb7a6e995befb75dae9308ba9cb8d54815795b6cd3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 50a033f774e4c5068f826aae61dadaa5c78c2c403e473e4334ba7254b5197186
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 43ec13a52dc05ff114b40567e2e7c79f9f12fe9abbc202529d4f252b37c78f6a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 39c8c9d293328eacca6aa5ab6d2d9ea0b57ad731936fed5c07698fed17b68bb0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 60d6fe7eff6ac6e6e4e3a710173174e9ada705f867a6f5c3966209776a165a3e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: bc8fd8e6fafda0f20957b2889453e91d29950ab2b531396bd9ce171c5ee3848b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_amd64.deb
     digest: 19b8be6556d17e4cda36289e75f6f36a6754fcc563ab38b7b12eec44e9bc9cc8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_amd64.deb
     digest: d20ac9a0cb3fb7be175dc8d1594db89ad9a0c2a49184a92cb3fab9e4bc7c8ffe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: e0bb7ceea400d2e8539282bfbc62408417af288ddd1e29503600646df7ee9043
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_amd64.deb
     digest: b31569eb5340aa263ba7d526406c50d7877c94031bcfe9a6da22da6b794a934a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
     digest: fccec1dfae75e5e95ee0c23f7b705c78e84c9646bbb7e2f929ae1bbfbef6e5a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin10_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin10_amd64.deb
     digest: 03f3cf4134394fb70b09dc434ffbdcfe7ba58487efd9ba04036341f5ced58c36
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin10_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin10_amd64.deb
     digest: 076ca4f9acb0c2c46c9b4c4ab931f93d65ababf7a9a1183effb2d470e8e13384
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: ab6e853085a72b308c4558fe02e38cff35faf1ba6eff2aced5278cdd44206d48
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin10_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin10_amd64.deb
     digest: 716c4006c28fd1c2226c7ad9941f990016230ec88b8ba7ef8970007cf8355351
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 59983773712d03a810858322bd8c8c4339deb0afc82fd0a7a61aadd91dcf5083
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_amd64.deb
     digest: 4b74d4425bcb1d23d7763e62cb1c9f2be712d9f92e46542151125ba96d623164
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libr/librist/librist4_0.2.11+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libr/librist/librist4_0.2.11+dfsg-1_amd64.deb
     digest: 620c2049aec638274e02b3cfaac1398e1f67a6a1a76fcb13383542eb4637648f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_amd64.deb
     digest: f7dfdd9e463828cff8e624ceda7f13cc68f2c9d2e72b27dc7e7315e1193b7d92
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libsepol/libsepol-dev_3.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libsepol/libsepol-dev_3.5-2_amd64.deb
     digest: 4a1b7141086a540294dfc0df7eb707f2ef1e57d2a2f4b30f80821164d0f97b7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_amd64.deb
     digest: 7af3357f80d57fdc31a26596f9e93f0218a625929822228d312498cabdcea72e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libsodium/libsodium23_1.0.18-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libsodium/libsodium23_1.0.18-1_amd64.deb
     digest: b16ee914acaaad0cb1c062370f30934b76e401350bd531d169e5838927c4da30
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
     digest: 44381cd9ad35fa6ffa7a0b3e27611011602bb32093efaf0c80117dc9f97a371b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_amd64.deb
     digest: a5b9b34ea8699849e17a2e4c7428f5dabbda217a85ca9f2cc47e4ce6e0d250b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_amd64.deb
     digest: cda4bbbcedb3ddd9b6722acabb811b95d1a6573a60ad7e6fedfbccac843bf8f2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libssh/libssh-4_0.11.3-1_amd64.deb
-    digest: a525b7a475d9ef111dd4b9af0baa4eb5a06a15b008b5a9e27f754a5ee091eed7
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libssh/libssh-4_0.11.3-1deepin2_amd64.deb
+    digest: eb94cc837c3980e90b453500a0b000e2c79eefed65a409efea98b10758ecedce
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
     digest: b0e9783da04f53ba8da97660523021322c4477059c63d3684fab283b7f9aef9c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin9_amd64.deb
-    digest: 3f438a8757487e4e5a9b99d6f1555c63142a23ec215577210602c94597e8d307
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/ffmpeg/libswscale7_6.1.5-0deepin3_amd64.deb
+    digest: 4c6a46aa4400d507ce8c28e12cceb000dbc16b3df8ce7d8495e00d29f47a5e6d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
     digest: bbaacdcbf341e500cd8fbe0dfb75fc98156b0a5abf94e43105bb5f745c3168dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
     digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tiff/libtiff-dev_4.7.1-1deepin1_amd64.deb
-    digest: d1eda91af2c50ab1a627fb3a631885c58b0c8173eba76342af4e85c3f647185d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tiff/libtiff-dev_4.7.1-2_amd64.deb
+    digest: 311bc20711c60fb339d397868a8fa2e6d66ab5a2083a2277490162727b53e03f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tiff/libtiffxx6_4.7.1-1deepin1_amd64.deb
-    digest: 756eb3dd1d449ecd8a253f144f108287e4db4e1f7850f77ad68a335b1c30dc42
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tiff/libtiffxx6_4.7.1-2_amd64.deb
+    digest: 01ffb7fd2022b4eabf9141b12285a18e56f26c93fd40c52a9253992b6c1ccec2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_amd64.deb
     digest: 1da0a72adec71588a6ac641b6f60ce39aeaeaf6771bcd2386b7dd33ad49b0548
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
     digest: d7c7fffd808cd0b765d2287b98bea752d740994788dbf90de6db4f9710e41162
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/systemd/libudev-dev_255.2-4deepin25_amd64.deb
-    digest: 1c96a6d7669182ba07c80576b8a7ecab8f28259232741d48cf96dae59979598f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/systemd/libudev-dev_255.2-4deepin31_amd64.deb
+    digest: 0391fddbd76653e834bda84d4e7b00ed90a7c1d6501432c0881f27de289fa99c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libu/libudfread/libudfread0_1.1.2-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libu/libudfread/libudfread0_1.1.2-1_amd64.deb
     digest: 5ebb4a61642a553212842e52f9bcca0bcdf2fa47f95d8d1a4b30d6096dbda8e9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_amd64.deb
     digest: 50a8cfed14d73f5e15fe13de7faae7d05b5e3a5afa79bac1ed373cf8487213a1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_amd64.deb
     digest: 24e268d97e22c4ed71c91201fb5d54f8b4b8689cccd032f11bb4faa1143bae04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwacom/libwacom-dev_1.12-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwacom/libwacom-dev_1.12-1_amd64.deb
     digest: 2e107e0a55003a2c223c792b5d505e566c553c42b0f6acc98f927f1a88bf4c2d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwacom/libwacom2_1.12-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwacom/libwacom2_1.12-1_amd64.deb
     digest: 2e0eb22e108ff3de178a570dcd21ab3d6cc16f6baf94bec37595008786789280
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/w/wayland/libwayland-bin_1.23.1-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/w/wayland/libwayland-bin_1.23.1-3_amd64.deb
     digest: 452bdd1fa61105c0e7a8aed8afbceac7a3c3cc07983ffec146f77581f48ac713
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/w/wayland/libwayland-dev_1.23.1-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/w/wayland/libwayland-dev_1.23.1-3_amd64.deb
     digest: 475c2fc3207e28a3d5c54b81b313b00222fd52042fb2beb3cfe7814dd40bceea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_amd64.deb
     digest: 0c60cd19f18fbd0cf299480c7e7cfcb7451e6b1b05dc8f2d5cae1cd248e4bc5f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_amd64.deb
     digest: 26d6ff4ed6bf1da7fe3eafe2514ef5c04a8792381b35e3bd3745fab1b6347246
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libx11/libx11-dev_1.8.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libx11/libx11-dev_1.8.7-1_amd64.deb
     digest: 93ec6c1345900f791549c12440757ba08e756379278bd6fe5133e6690c544621
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxau/libxau-dev_1.0.9-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxau/libxau-dev_1.0.9-1_amd64.deb
     digest: 784b6358825482c6b8e0a5515c1ea33a84e1ae70999df930a75c344a476dbafa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxcb/libxcb1-dev_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxcb/libxcb1-dev_1.15-1_amd64.deb
     digest: 981d5049c153139995fa5d28ca1da252bbd5239a25111dc7bc28ab8c556d1b0b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_amd64.deb
     digest: 3ddced0df55f49a1a83f663c94dc99af95580104cef6bc89fed65c9da7bc5199
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_amd64.deb
     digest: fd7cb0bb0dc64c7417a6418bdf4d67145947902d5dd668eab4949811b170ee51
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/z/zeromq3/libzmq5_4.3.5-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/z/zeromq3/libzmq5_4.3.5-1_amd64.deb
     digest: 6374362f4defd2e6a454b31a8fe8e407aeb5558c4cacebc6a97a3c9d7f639e18
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_amd64.deb
     digest: 92ec406d537e08271b66dbcf10d5730fff8eee067379c9fce7e74e4c53c6b4c3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
     digest: f7102c09d7ca6cf19598b0901a46799ed935bd3278323121b11360f38dc48c9f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/lsb/lsb-base_11.6_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/lsb/lsb-base_11.6_all.deb
     digest: f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_amd64.deb
     digest: d184d5fd7e340055beee8115e1f28663e539c024ede10773ac03f4ca3f86e343
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb
     digest: fc03b0233080c11aadc3ef81283bcba5ff4904e0591ecf2beda7a4e7157e9975
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
     digest: 848333f2b40b586ecf8f0db2b6127398d0423867e689937c4427ab15570e5581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
     digest: 729d9b051d2dcda0d0bf51fee21d3b685093314a0b2283926f1eb11f937cb04c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/patch/patch_2.8-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/patch/patch_2.8-2_amd64.deb
     digest: a68c27b1c86624c5b6b60668fe0c11f4414134508fd97454a429e4b7211f70fe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_amd64.deb
     digest: fbbe40d23fd9d76c088b9470785cf11bfc4929853f35a3633cace4c056b4bee3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pkgconf/pkgconf_2.5.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pkgconf/pkgconf_2.5.1-4_amd64.deb
     digest: 87f2a519a3a380c8b37a7893aa946982ec1fdd44c5da65de8ea1451f3254a7c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
     digest: 4b0fffc886401daa9acfb53e2b190528e3fad37a49b989c4fae6715004fda41e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
     digest: 3f6d07590c1e8957fdc76082f19363f1fa8e5fcf94f7ae1bada4afbab55eb92b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 9932df49cceb85c31c08573b1eebf4f2662a896521bd4224335b21ec619a2837
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin24_amd64.deb
     digest: f01f195df6a634a791b70e972afd5893b9131e9735c8d338b10eac4cd419af77
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin12_amd64.deb
     digest: ab2696a9d2c66edc7b18c6d14c3d7c027bb9658be43974cfcf604995da4304f2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 05897296c8a9a18da558eac16e45c08e7ad3f1bba0ed6dae298c78727590648e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin12_amd64.deb
     digest: e488b300c679e518cc43f5228849768602f58e0610a1a9bae3ead505fa7e685f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin12_amd64.deb
     digest: be2124ae07868be5f5707da5244864b626fc21f21c7308a2f1babef49c3f8868
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 48059222aa9327d244be8797ae8da392ccccaac80bc18c482243af3bfa90ff3c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 53e9d7d16e72366551e94dc60eca4975db12e8a706fb4e4b3103cfb4bebe77f9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 1ad0731dd259be87ac4e53bc6ad7d5f8e56c90065c972dc2e93cfcb7eb8ab440
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 8e1d3be85919f31778fc471c077e8d7897eb67a9fcda3729495a21856be30ff2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 6d5d0314c4a773aec15beabf5b555dc4953d057cc5ed87a8b619f1076d8de2b9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_amd64.deb
     digest: e3ab20d4d1cf4ee712ac3e5624e78369d8cb5bdae57f830111ca244abbe9b4fb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 8ac6a3c753f8a908682462603b9a8ca6a7be9402014056dd7367b17eee55ba3a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_amd64.deb
     digest: 3c7e5c7b9970e4d65a36a8480be3572faf88247c25e6885c46232042fb131cbf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_amd64.deb
     digest: f97ace68363e7bacbb9ccbea0e581efc04fa2bbca15a0f520e8ee2fe84ddea53
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 79664141275bfa2b765c747f4974cf80bd1cc5cfac5f34ebec4d34ee1038c963
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 152ed23c370153c1d7c8e8cb0d7c7f7d8e53db10a7da1e56ac2c08572913b5ba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin12_amd64.deb
     digest: cf251318f37713c8fc281ef561ef390d6421775cc0e48869820cfc5e606046df
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin12_amd64.deb
     digest: f4b3395fbc3b171a21b4cf4baf160ea264adc03ecd90cbcbb18deba996c994ba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.44.1_amd64.deb
-    digest: 29cbbf06860926d37d41399855fb6ab1b92f01e9b61a858fd6a3327584cbcdd7
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.45-1_amd64.deb
+    digest: fcd699b9f93c344f7cff1bb925cf03f15edc4387546b53d4bcf966444aa789d7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 82f11958c8366f1b295b11ad6beaded04e88c884b61f8fa01d2b7e486770148a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin12_amd64.deb
     digest: cc46458faf4ce789698175c09df5eb455ced44def31bbf583efd62b299da6575
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 1eabcab15a6a6f5d571bea17c1b3bf618e62de100e0e2cec1c7801cf70d5dbe7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 2b6e8bd96a449dd4eb3f41f5c9661e268d0af6ba60f5194232ea18f034ee5e97
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 0abf8453a4cc2369760cb46c3015cd7f88b3931cd67cff50dcd5b3cb48a6b1de
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin12_amd64.deb
     digest: e381f167cc0bf518964a3d21caffccfbbb752eadc1a2577f2cbba00f8fc0da9c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 0ca312bc6a1530ad328107611ee12c76f51bf31ba7cbef60b5e47c5b08b7bada
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin12_amd64.deb
     digest: b649f2d8658034fef7ead51193cdc1606d08ce9a21b17dac8d21b1e0bcb1bb65
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin12_amd64.deb
     digest: dcdf393973455864a80bf229c34b7cd6c49d8aed3520452bc66c1bfb8a9a06da
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin12_amd64.deb
     digest: a2cae50ba9bea9ac6cab9874bae678e8cd408fc4a512237f05fcb155faa41ec8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin12_amd64.deb
     digest: aec5e0ee3df6bd79805d4597ca626d73c1029782446a29d1c00df36fefb98de8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_amd64.deb
     digest: 172fd1eead6e3bff1e2c19e5b6a42a6979ccb7600b2d7ac2a81cf404a1c351b1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 067e3b5496df19d92f3398234602911539bec477ceac575204ba4754b1ff9db0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 56cf5bec42476686844ba8f3dc1bc8db1e330df07750ff3970a1cf1a321b3254
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_amd64.deb
     digest: 470f392ceedbbb90b4f889aff6987106e864db604833e0fa3bddd61baa93f3ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin10_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin10_amd64.deb
     digest: 8b9bbd75a2b4560a067054dfc151571b3a5a7f4d7f19cc82682a4265c013e8f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin10_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin10_amd64.deb
     digest: 17ee1c396b4d802c7912a27de5a31c0328997a00ee265a6f24d696c717742d5f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin12_amd64.deb
     digest: b546bb8e999d2e519fd5344e1cb4581e2c7c0cecd5c40d9faa02b95130b717a3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_amd64.deb
     digest: a61f1a75f31b6b3ea46551a2801de97d83282870c57ca69f7d916ecac63489ea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin24_amd64.deb
     digest: bebdf5bab052be9e22d1daca548a37c7da1bc5cb5e1980b33103c726445ef8f4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin24_amd64.deb
     digest: b0f70e2309a8579a1d49fdb19a7ea1c084ce69cffa76726047f992f2a2f6064c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin24_amd64.deb
     digest: c11c4763e3a9a69c6a2d9541eb359957bf2946079a204da802fd63f0451d7b8e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 82d6dd7bc88e14bac36da9f5cbe96a6d82365e6b6f5ba801966ba49152e6b213
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 6af197417b0c34dca74fd68e85559652eef04b198fa6145beb9a2262276bab23
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 3e3742be4786edbf5835e8e3f564bd5cd7a6a75a28e425b6568265658e7cefad
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
     digest: 9e89f44e0c10a9e499487387a568a1690e46d77078969070fc0e1368a49180c6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin24_amd64.deb
     digest: d572e5319b3846b4c08bc8158ff00eb5307f78e5422ee2a6521520ca9f3dd240
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_amd64.deb
     digest: 9673c22b10da7c5895a4d3697b970bc2e5217fe09a468eb79760bb5e03c62959
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
     digest: 9bb6be934533f5c98bb8f7b1f960741a2897824cf504ea93f80b9fc2b102fc34
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_amd64.deb
     digest: e49d551b49772f35ea9a4c524e58b523dea5c665b6ad96383da54a4ee9c7058d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin12_amd64.deb
     digest: cfc41042cf71f5980fadd60589206d1c39ef73562349231027dcd84de34c1417
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin12_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin12_amd64.deb
     digest: 002c62048e03cf77091369f1861997177b34a5f655a5a4f8ee2e44cc5c879b9d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin24_amd64.deb
     digest: 156f09fc8730fd3e712c44fa5f5c005668486e746d650bc70f3f3c7b3161a9c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_amd64.deb
     digest: 2405851738c3c42a35667a20efebc0830238f8e1cff38775dfa28edce61981cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_amd64.deb
     digest: 2469decd9f0021993e7c4f3df79c7eaef7257cdb9a99ce1f208a57446dcaed0c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_amd64.deb
     digest: dcf8a050f6f90c36f7c5a1291d6d6b6a83b2c80105f63352badb3be8dabd0ac4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_amd64.deb
     digest: a7d85abe1b4820339aa2c78c9eccedf1033b054a1b4d9899bd0887307672f14c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_amd64.deb
     digest: a28b2577b7ac8f577cd119c45df8326f88c9a5a4408c6d239038fe53e1dca3e1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_amd64.deb
     digest: bd393b38678a73c27c0d501fa9fb8014a65719760cb04a3acd813c0fd4d6ed5e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_amd64.deb
     digest: e05c22f70ce1370504ba6f537748e799a20da4170718199080beacc63071fbd4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_amd64.deb
     digest: 54037eb0f4e26bde01e38ce19d70514de69419b93d1fa5879502aca6a9eb0838
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
     digest: dbfa88dae0e66fa60e6558fa80242bb78be8dec5b37ea449f85826b1b48cf25c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin10_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin10_amd64.deb
     digest: 6d4a7fc0231ab594c2c9a9bf4f128737335330c1d87b5da8ff94a2bf909a6a40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin10_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin10_amd64.deb
     digest: d95f6b4a1e3a1645cc94cc245d99e74403b5ad94e6cdfcafa2e17a0b8f2f7624
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin10_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin10_amd64.deb
     digest: 1a1d759c0767432a3e2dcac91fe0c2cadc3d1b0b0304b7c2bdf5e80ec731d1e8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin10_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin10_amd64.deb
     digest: e3b299c40aabb8926422cfe328bcb7512923428fb5d6cd370f60eae601b3378c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
     digest: e70bbe5b35aa1009f8d3e8d58634052977864bad1d854230add6758ef238b1bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin24_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin24_amd64.deb
     digest: ed96afe26ccd05c415d9148b631a14895bacc339796191cb4b6766b09952621d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
     digest: aae8ac2b6d3198d297d430cdb97e556365be2ff46d06525008ce071d97ac69c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/uos-license-content/uos-license-content_2.0.7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/uos-license-content/uos-license-content_2.0.7_amd64.deb
     digest: 82a4358051e045ed31367923fc6c3893aaceb6dfa9404d2a1c37f96f9de8db5e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_amd64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_amd64.deb
     digest: 39bec55d10b291bf738e114dc66bf265f071c7e8cc0946a1b3319b34aed7010a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
-    digest: 6d5bf0445a25257bc75a612224498ecddda2fa56edc8d17af5c4bdd2713edd4b
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.2-1deepin2_amd64.deb
+    digest: 971296a3d7cbf049be588baaf566d04df40f12bf1b76db0cbac517822d2cc3a1

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 6.7.0.44
+  version: 
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -13,7 +13,7 @@ build: |
   bash -e build.bash
 
 sources:
-  # linglong:gen_deb_source sources loong64 http://10.20.64.92:8080/crimson_runtime/stable_20260708 stable main
+  # linglong:gen_deb_source sources loong64 http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3 stable main
   # source package qt6-base
   # linglong:gen_deb_source install libqt6concurrent6
   # linglong:gen_deb_source install libqt6core6
@@ -179,827 +179,827 @@ sources:
   # source package uos-license-content
   # linglong:gen_deb_source install uos-license-content
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_loong64.deb
     digest: eb1f44a7f8d9c71c545fe6dbbf2b58675c2e5f18dfd14733941a2644b8908c37
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/b/binutils/binutils-loongarch64-linux-gnu_2.41-6deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/b/binutils/binutils-loongarch64-linux-gnu_2.41-6deepin11_loong64.deb
     digest: 35a35af6bf074079766e3210a42ca8fbb88e067fd8dcf48d55165e5ebad7b27c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dbus-broker/dbus-broker_29-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dbus-broker/dbus-broker_29-3_loong64.deb
     digest: c32fa99bec894b1be78e1a8a8c5ac0206a3962b750aa9338387297e240b9db71
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt5integration/dde-qt6integration_6.7.44_loong64.deb
-    digest: 4a235801fba53673777e24af5f5a0f61158339599a0feb6ed2abf2dc8ed6ff19
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt5integration/dde-qt6integration_6.7.45-1_loong64.deb
+    digest: 70ea3f4040dfd5790fc84735e8658dbd35a2197b8681a6970d07835cc7ba9e22
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.44_loong64.deb
-    digest: e56b5414bad1e41371025b72ae7d50520eb7452d9917da687b5d37b931a7eb43
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.45-1_loong64.deb
+    digest: 21c5ad79fb8e783293b4fdd69393c434586ddb59aa4c7a35602777fedf23de92
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_loong64.deb
     digest: 60d20d41533b1a178f135352f161a1195e8dc2e105a3c0a4bf063aee66054f6e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
     digest: 377acca7fcea64458b6d0ccbbdf8773e6a23d0219739747d6a2255c6fc43cfeb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
     digest: ad27e359a1fe3485255ce3c17eab99ae42ce1aa03acd67e45a2751710dc463c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.44.1_loong64.deb
-    digest: 3ad2664080935c593b77c7b1e034b8969308b1c43d28a3ae9aa44a7dfe8b4802
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.45-1_loong64.deb
+    digest: c2367080ede1920085f50a7237604b4040f832a3547c59ebd9c56c2c026c29fa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.9-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.9-1_loong64.deb
     digest: 06edb15fdb1076b5a66828a827b370fc9fab88b206ecde6a4379fe7dca31e1e0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
     digest: fafd08c872d1279aa0bde2e0bdf40a57721961934c0593352b6a2c551aa232a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
     digest: ef932bad267f9d4d49c0c376ae1d0fc1a9b595054f8450d42b2a0d6621bc7084
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_loong64.deb
     digest: d9ff018530bb844cab04fbe9893d87fe41d919c09d82bce9886b8baa00fde8c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/gcc-13/libatomic1_13.2.0-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/gcc-13/libatomic1_13.2.0-3deepin4_loong64.deb
     digest: 1ed85dc548b54f63267a5fb8c81b8d90638df81de8bcca7448e087f994b31bc5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin9_loong64.deb
-    digest: 4e7103f8451a523b227e8e6aeec12fabb4fb8ef9770bd85f7dc14fab956a0ae9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/ffmpeg/libavformat60_6.1.5-0deepin3_loong64.deb
+    digest: 28785a25651a998becf6c50380507d6782d9ef6ace4f799a97e06707ebad7aaa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
     digest: 43c9bedf808d5c2b85351f73dab25e81c5674c499c293be875ac5250c4b8cca0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_loong64.deb
     digest: 22511a7128c7958f774c9eaed060f2976f9a521ce4719217e74714d9c550823e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_loong64.deb
     digest: b28910a92aece870792abb3b969c20947e0a9dfeed0957b8207c49ef97766b8e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/b/brotli/libbrotli-dev_1.1.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/b/brotli/libbrotli-dev_1.1.0-2_loong64.deb
     digest: c2388059363813c7ad5e42d91f514b1e93e3dd07432634eca0a6814e2d7edc10
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_loong64.deb
     digest: b073876e60d9f9ba41ff9f984d0895c37684272da7ea5389b2ceb85598e3154a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/capstone/libcapstone5_5.0.3-1_loong64.deb
-    digest: 9fc4dad13f7d8cd45e037e5f4bbc7aaf446e76cb583ef9fcab6c5618c4e5d6c9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/capstone/libcapstone5_5.0.3-1deepin1_loong64.deb
+    digest: 45c7b82c996e051a0cfffb258efcd0924b112b416f536f85d7ceff290388f828
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_loong64.deb
     digest: 23c1612c4842c5ea3315b25e15d859301a5f925f439fc377b3b989d1473d142c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_loong64.deb
     digest: 970155ff2e9d993e4daf74f3c3d1189b5ba3115603bd3e458b80aee42255a9a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_loong64.deb
     digest: aa856e77c7da5ff138243d38928291ccd9b6fd041baed5e79c50673a8631389c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_loong64.deb
     digest: eb5d0443db82c2a855562de7ef2fe8131b8b26ecaf3d1e13eee0e8bf63610f50
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_loong64.deb
     digest: 27d287c3a96cc2b0455d48cc1a68ea4f25bb9767600f5121c3c5c877b2970d1b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_loong64.deb
     digest: 617ad9b75c6b39d49d8079abaa28dd7240c53e06070097032d55c41d8e60381b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_loong64.deb
     digest: 9ca0af4b398c531c686f9751478ce94d2f683850862adc4c9e5c0c1314d42e0e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
     digest: 1cb1deef108f4163f884f564e9fcfd429adc315e9509c30ff3bcf936824ac543
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
     digest: 5ac1e65112a190dfca99abf002e3e3f0ee033919b7b65cef5e3637ff1821cc9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcore/libdtk6core-bin_6.7.44_loong64.deb
-    digest: d6be52cbca99910b217f9a2b97a46f6f9ab7d432a9d52edf076f905529eae03e
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcore/libdtk6core-bin_6.7.45-1_loong64.deb
+    digest: 07b110d1f19ad57d08b0c999f8880f72d86a5b51b03e48bcd11be01627f4c0de
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcore/libdtk6core-dev_6.7.44_loong64.deb
-    digest: 33bcc9f974a4126321dce076fdf62071179e92e708d03ffc28d45537e4008e0d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcore/libdtk6core-dev_6.7.45-1_loong64.deb
+    digest: 157f2ab61bb3a0af746051549c04c85b16319abc7d6760bf7ab2d4870461614d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcore/libdtk6core_6.7.44_loong64.deb
-    digest: 69bb836ad8025f921562fe49afe7db675312a9851753b79a75545897dfd35a33
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcore/libdtk6core_6.7.45-1_loong64.deb
+    digest: 660a2ef0791e90882be0e3c97f48bcd497f434c47cfdf53afadd70369482c683
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.44.1_loong64.deb
-    digest: d0983a82e8b49a9c3a2a1375381d83503b41ea48e09eea1ba3872f9b086c9017
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.45-1_loong64.deb
+    digest: e4856451fd166a2eb7c5d3859d433b0a7b560e64de9c48c87ee9fc7c77de221a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.44.1_loong64.deb
-    digest: 9eaa05165cb2d477ca4f7556bf15768b2f2d656f9739a3733e06d32e31c56637
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.45-1_loong64.deb
+    digest: d509738a6bc6c17f7c04cf25cfbb7dd7e484fb187f1f962d1db46263faf61db6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkgui/libdtk6gui-bin_6.7.44_loong64.deb
-    digest: c586fc8b4fa825385c69c23da4ab3f5ac8257c00f02f6b4498b97fd6d514ac17
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkgui/libdtk6gui-bin_6.7.45-1_loong64.deb
+    digest: 0f2ef0397258ecadffe8df1358f76cb00d30f9dc2cc5231b003b06ea82f3715b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkgui/libdtk6gui-dev_6.7.44_loong64.deb
-    digest: 856239bb5912049213db3f01edc5ae77c5526e61d85922c2a14862a0e9d42869
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkgui/libdtk6gui-dev_6.7.45-1_loong64.deb
+    digest: 4b81f82e98972d5f9c66f2e23f3a46995029fbd514afc34d6b6bf5c472fd4dc3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkgui/libdtk6gui_6.7.44_loong64.deb
-    digest: ccabaea16c57d86430beabaefdda958efe3bb507f6acb069e4c93f25ef9036fa
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkgui/libdtk6gui_6.7.45-1_loong64.deb
+    digest: 0adadfc51853b04a0e5db8b560400d0b7c2078a1e41722f13ff2597774076c43
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtklog/libdtk6log-dev_6.7.44_loong64.deb
-    digest: 4a2d6600fc2ca963d43dbc2c9c9bc4a98f23e6ba4964bf263c8d15dfb0848969
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtklog/libdtk6log-dev_6.7.45-1_loong64.deb
+    digest: f89546dc7a24993560a50b568a6eefdd5aff4229f6d06b52dbb726aaf0d68cd9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtklog/libdtk6log_6.7.44_loong64.deb
-    digest: 802f98c70cc40e376e9fff02692971ecaf92099e6e4c8f556ed22ae8af957dbb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtklog/libdtk6log_6.7.45-1_loong64.deb
+    digest: 05a365f0b8cd39cd4a0c9c61b43d8d3624b32d7aa0d11fade72b3cba84b9b3ea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.44_loong64.deb
-    digest: a74ecb74ff77207c90c905b4c1963071051e396649253b9aacb4a5b1f7d1b459
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.45-1_loong64.deb
+    digest: ddf5b608ca90a5e7f8b2dadc9000b405c6909f47b2fd52a016b30148d2af73cb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.44_loong64.deb
-    digest: c454dd192743148892161b96e11d453728ee1d867b6a91bc4f9c36928e91f59f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.45-1_loong64.deb
+    digest: a71f3588be5edcf90be3e8bfd9d2a1ee02951895faf9261d9101e57f534fbdc6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkwidget/libdtk6widget_6.7.44_loong64.deb
-    digest: cbda8115e23af2a72ae5809a9a399ee60789c02e22d2f35ff2a561503afe2c2a
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkwidget/libdtk6widget_6.7.45-1_loong64.deb
+    digest: 67d6fcc7ddedc1ab7411992a4f26e730346d5a9d6b73723819d9ecbd9ccaa61b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.44_loong64.deb
-    digest: 89cef8291a324899735ab8e1b6a5271d100a44a3b8b4b4c148fa5c10efeeea1d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.45-1_loong64.deb
+    digest: f8992486557b6d276d6ca44c4350042d629140391fd4d0e785c54696e319f7f5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcommon/libdtkdata_6.7.44_loong64.deb
-    digest: 0e608c2747832e08923270375a2ff281c1d5c22028c6e93c72bcf0a9263c5ab5
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcommon/libdtkdata_6.7.45-1_loong64.deb
+    digest: 4954dfdde25e40fbbfc31762c083b4e422a41ee301f611b62a4f4e893c92e40a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_loong64.deb
     digest: 43ea506dbb0c9b69bcb06c4cb8e40151bf81952367c5355f830f87288c3fe462
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_loong64.deb
     digest: d076ff9e61c87ebbf1a4d592eff79d32d6358fa8cd1121a30baf7ef92b764a0b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/e/expat/libexpat1-dev_2.7.4-1_loong64.deb
-    digest: 4e9e9a06a407d04a44dd17b7a677bbc63e5d41bb0341de881473b1fdf48dcc15
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/e/expat/libexpat1-dev_2.8.0-2_loong64.deb
+    digest: 78a7c1de139f4725d7083fb85b0671553368dcc3e4551a6987b81f8540420d1b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_loong64.deb
     digest: 1247f90fa5006593b184ecd8ab58a9f3f1d9d9a38c97b67fefeb2ba0122e43f9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.9-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.9-1_all.deb
     digest: 095f6c357e994b15d51e9cf85722cbdf80f821a8ba2e5b2310fb9a40bb2529b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.9-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.9-1_loong64.deb
     digest: 26295740466a09a3aa9d606fc5220c21aafaa044ba912584b30b802e1fc650a1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.9-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.9-1_loong64.deb
     digest: 0fb24dcc28b7b8d985fd1829733f313ebd788d5a68c05aa8b07d43255d6eb10e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin1_loong64.deb
-    digest: a0f7d5ba9a6db562acdd76947f0029787b50779b698731876b945351f7da69c1
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin6_loong64.deb
+    digest: e38e3398334b2d6686f3321a5c695db52a12632043e681c8f91a1466ab704f61
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
     digest: 864ef36cd80bc0a9fadbdafca5a5ef05ff92458f945bc1c20753d7635d8f17b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/flite/libflite1_2.2-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/flite/libflite1_2.2-6_loong64.deb
     digest: 89927d11c271631ca816010e3825c066645c90621bc386f4dea59fbcc10fa51f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_loong64.deb
     digest: 58d05c9c6162bddfa086ae65bb7f937b94ca237eac4819cc4c614e67516fac1e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_loong64.deb
     digest: b62b02488a20b998918cc11257b322dd2d2d55060b218c23e9e4771f812ad650
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_loong64.deb
     digest: 0ca5d52aeb656859340e21163000e4533fad0073b5ed6b2de5f1cbc3a254b76f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_loong64.deb
     digest: 38184fc8103e1312c59a9c5cbc22439c444433f96ed7b2484bf96b42aaad0f49
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_loong64.deb
     digest: 37a693f96d02d97be01c45d972836cbaaac0b9a5043174a04b2e2eeff251b30d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_loong64.deb
     digest: 224418db0f3e9cca518d2209f1b948a4a933c44e98e0e27986d70f0cb463762b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_loong64.deb
     digest: 4fcb65ca8a64a9917615989f155b1bfd4741a3127f1958787d8ad27b9ef8d548
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_loong64.deb
     digest: 260b85824035f054f7e25e2b142ee5397c28953f77f463276203b0e5ed8d9bde
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_loong64.deb
     digest: 03512d70fb50bc97266e9f14dd56fc5577d455aed40072f0f2794056bdd6ac28
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_loong64.deb
     digest: 0dd514b4720617d406df515fc6a95be7e19a223e3f1c40da22128b46facf7989
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libgudev/libgudev-1.0-0_238-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libgudev/libgudev-1.0-0_238-6_loong64.deb
     digest: 743a0e5aed46c4ed65bbb4a7dcc8d1671399c972a2139296b7eff8a529da1510
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_loong64.deb
     digest: e064f26b79aca0044bf1ebd77ac29d0e9470aef6f8d97cd90284389b8336fbee
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_loong64.deb
     digest: eb28d4bec657f7273f965bde361caca747436978ff2b8dfda5bb4ce292c8868c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_loong64.deb
     digest: f032e10ca2f485b3db38778d9a01d22dbd92d0aaab17f7b543d29aa4651b55dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_loong64.deb
     digest: c675f26dc073cd01c6098484e841faefea0de2e1606eaf2de5980942a90fd487
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_loong64.deb
     digest: 1cc8375ccbdfff3024272e03d8da0106288dee124510fb696ab213b02fd391f5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_loong64.deb
     digest: 0c3b4ccc6927abdfddb2d909ca139fbbf1c5e81ccfdba90c1ffcce9f460d4cb7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_loong64.deb
     digest: 152658aba54e2f163ba19c0fe53aa7666e1c6907eda79433f1ec38240a9670b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_loong64.deb
     digest: 342808c163f19bfdfdb7f36cf51acce6401aa2c0df6fd5695d0b3a9f2731bd9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_loong64.deb
     digest: c0a9c5a24ac81fd6e5641d36d47600df17b732fe3a5c024753da8e32679a1447
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_loong64.deb
     digest: 6b486a85ac27b4001d13fb43838047f46ea84c3b97baa48d0ede572ccd47817f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_loong64.deb
     digest: 3ae2965f4f532a1dfc813c0d9ba0461219093f4f0ab50c9f3ca77ba99d71cf34
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_loong64.deb
     digest: 53c2272267e61ea69f67973a7a43374ac2ae02be3adaf20f6231b7cf274a766a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_loong64.deb
     digest: ffdfa4f9a32fc2be622d68b3118ab848e7e01bc063c189ec5e5f23fa0f686a36
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/md4c/libmd4c0_0.4.8-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/md4c/libmd4c0_0.4.8-1_loong64.deb
     digest: 38b04a9c6431d337342ef954a98ddc75b6ea0da7b17d321cf5f4ba17e73d9dea
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_loong64.deb
     digest: 501c91fa0ba7cc9f6bceff658ffdba2323039a590719a2030f2dd37266d296aa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_loong64.deb
     digest: f3e26945d53b26d1787b23cdbddb89afec7494f2192ffbb81d75e4ce7883aa23
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_loong64.deb
     digest: 9b74501e7c7e6f5d5708bfb897a6710f2144da4806717be60cadb34d2e180353
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mtdev/libmtdev1_1.1.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mtdev/libmtdev1_1.1.6-1_loong64.deb
     digest: 4a5019080a0454a1380d3353dbc52b5bfebd3ad8f4c210425beeef8b6e5113e8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_loong64.deb
     digest: b8ccd5bf943ded55cccdc92d59c8abb35a1fb65fc3425ebe35670d37b7bdad6f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
     digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_loong64.deb
     digest: 2edcd978231e1d513566ace5c07cc11449586130e0e9b8d5bc126d8a56f8e93f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_loong64.deb
     digest: cd4ffaeb85402fdee4cd618e5d95b20857b2eb83f25d6109f8026b714b4af470
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_loong64.deb
     digest: d5f7b919880e85ef999377610d15bc712151a6ae5b5aaf9752cc59d21923992f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pcre2/libpcre2-32-0_10.46-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pcre2/libpcre2-32-0_10.46-1_loong64.deb
     digest: 2db80a8bfa1f9619374622e0e01a9ea79ba3d2e886b0347a078889c73f969b38
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pcre2/libpcre2-dev_10.46-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pcre2/libpcre2-dev_10.46-1_loong64.deb
     digest: 6ea6b84b6b95885e921a2eb737bc9482caccfdcc42c9af8661f2de7e06c3f4ae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pcre2/libpcre2-posix3_10.46-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pcre2/libpcre2-posix3_10.46-1_loong64.deb
     digest: 58accb378abd0821d37bed2a8185059f72a05e1174c84ec5424ce3f4118188fd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_loong64.deb
     digest: 9b68dc19b458a678ae21f5eec1f27f011f0c8da502cf3cf234b5cf4f8e2b093d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_loong64.deb
     digest: e91b4866403e8d84c86e77498102e47cb3726474149cf5adc51e59cafff8d5cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_loong64.deb
     digest: 64e6558bc63ff72790f04695835cb1d713a4a259c211a63f536bb2c8da23cf53
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/postgresql-16/libpq5_16.3-1_loong64.deb
-    digest: 2797807f5da6690de1c2dca5caeb64d6ebe42e21a98eb07d04c5a117b7c1a6ba
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/postgresql-16/libpq5_16.4-3deepin1_loong64.deb
+    digest: c82d753dc55aafdd5060f98fec41d782a644ee036add9ef1455530bc32cca87a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
     digest: 9d68b88d2e9de4c313b75ec6ebd8df51105856bf8998470dc7faf770308ddc40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 9daf8aacebe9517c86e0a43c10aa1fdd98e700d1ac396b888b12c96f2c7f0a9f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_loong64.deb
     digest: 0516b6c29f4313bb30f9cf7858cf93c4d1ffc237a967eb65b3f0d5b943d83d7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: a40616d92ea3a3e61cea095cd157085e0013d013cafc079bd1c21a616f96dd6c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 3644b2b83c3b9bd2337aa9b875cc8d052394c574d16af0a0af0f34f2fb794fce
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
     digest: eb6a664507e891d69db263120e88b82bab4cfa104a39a28fe772d8beeeac21fa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
     digest: 82be98a5406a45ff7c0f16ba2015be9bbf3a269599233ac7fb25f28407b8ac07
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 92fb06c3728555da9f3300ee8a5beda4a2600a5f2947dd0f42a6f281a779de4d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
     digest: 0c68f46baa7a14cf0ff955d04931ae6db3a6a991e4efa546eac8b0af5000e3d0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_loong64.deb
     digest: 50cfc130b9f7bbc24dc0eee4ad75bd15dff40b9f126942ec1010f6e85955e112
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_loong64.deb
     digest: 84bb00e7144d357bb9f52720eba503deadc3939f34cd4f1431d8abc6c9181194
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: c4b947ff283fa44457124eafd523a6e5161e0ba73f448d1ae158cf8132fa337a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: b853f7b41bdae9fcc91a32258b950fd4a7ad690905ca91a7d23826d8f3a0f860
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 036ba0240461ddd2c8856ada81d5f401fe832ce8abc8eca523ca82e6b9e2b17e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: c57f359fc680c80f3d2de0977f4cf6cfab72c88fd84eec68d26b97db1bf360bb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 64cabb645acf4aaa9e9d4232dd2289e76ed2cddef2d767583227b7c721696315
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 90c87bef178b6534bc0bd919589432857dada1860b6430a85a7c2c7936eb397f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 6f3d15ec5025f9d1cddaeb96836f099c227833be795439443ccebfe9bb1f909c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_loong64.deb
     digest: 9775d45a33e9a2b23cafebe7975e731d477020d65cd5044c722b6918c271abd5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_loong64.deb
     digest: c2582a775b4bcef766cb710c214e928d3acdb33584129447ddf2200956fd1325
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_loong64.deb
     digest: 990ac1a932968384f8f0bbfca0fbb20e11ad7dee53a29a5e425beb8c83cbdb7e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 4aaf045e8eeff58cfae69ebf9fe5a8d9e3601fbde68fb51b6ae09b3bdfe6f96a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 0bc6103b5d4e00716a7785792ca6623960008c8a073fb5d07523d8415b0a7681
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 147620e1e7d7dd493ee2b3bf7cd9af9edf8abfd503903935cf144ec80c8c7fd2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 10eaa1283c9a3f51a01bc784ad45fcee54a8307bf7244d1ca196cb528d4532ce
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 8a05ced43bee2f9ccc9f716ed26fc0ad0bc9c7ff2c9d5772de03c912e12cff72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 11d46caddc680bf7a2a63d3638360c9d5849bde712c3ffd6f316f45388619004
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin12_loong64.deb
     digest: f90ad5d39e598bf1d8a49071a316b816124f583a5801f47bf43a4cd4731cd688
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_loong64.deb
-    digest: cec7d316516b54ca0babda908001f58c1055f8af78022528d6fe3868f6f90635
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin2_loong64.deb
+    digest: 03818987d96fd9a0d8ed2c4394bd79d3de3b929bfdc30e0732ae57a3a984afb6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_loong64.deb
     digest: 071bc2779dd4d67d41c836c3df87c7cf10e50ad7fa5aa8600422eeb345b85607
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 0ea0f5a8b1337d3e3b39feb28107873ac8632c8d0c1441127571edeef02ed4c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin24_loong64.deb
     digest: e82e207fc64e845dc78c1a551da79bc0a762d1aee429f94bcf516b85bdfac22b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 07b5c5b0491909b137e1371aa5abccbfbd5fc44d3192201c906ad8bf057d97b6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin24_loong64.deb
     digest: be947fbe9befe9ea51c7edf664950afb7c298095ccabc237e3c4f7109f878d3f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin24_loong64.deb
     digest: cbd6c183b2cd494e40485af47d5b263981c627752abed0271ebd8baf4dfa633e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 05812053b2d8d65b397d58c79255faf9a3dbfcaf8fead438dce3f421470126dc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_loong64.deb
     digest: ee578b410845fae862283b615ade90b89109255542981966270e8cb05df53d98
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_loong64.deb
     digest: 46c7fc620275a7aa02aa852bd1a47669cb5da8b0b23ef296e5f53b317738ba7a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 9f225bead9b8f75629260c850d965f1d650f25fcaedfd86b2c2f07351f7e9e84
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_loong64.deb
     digest: a792f970a150d5fd7b60c3e265f8117600556b81eaa4a8834a1f65163a659e5d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
     digest: bcc5d3441b82068d621fe024b751eb6642182b5f86dc7b57de237edadf190818
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin10_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin10_loong64.deb
     digest: 368b6312c4163fd679e4b57b9900ec9e7246d6973fcd66348c2c9babc3396819
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin10_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin10_loong64.deb
     digest: 9c820ab3867135a94dbe692da76f5346bcb1a6cefef29a14beb8462ff0b4cfd1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 73a2f76a872b9602336e4249ddae8771bb23235847d1f216b1a96021e6f572ff
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin10_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin10_loong64.deb
     digest: 1fd643e842aa147e2996bb3cd7c56ce1b497ec23a4147b01cea75d61a741dd28
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 9788d53770baf017aa3904cb081bad2b4bb618cef3965b6767d514b6f1d8ecdd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_loong64.deb
     digest: bfc60cbd6ee84fd4a6ee2d1002c27389d58dd451f8ec8bfde0e74fc8dbcfbbf4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libr/librist/librist4_0.2.11+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libr/librist/librist4_0.2.11+dfsg-1_loong64.deb
     digest: 2611a022edf6296d51869158a331d6af6470739d4ad74677f2fad25350d1840c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_loong64.deb
     digest: 3560dfdbcf90fef6f1fe16715e1bc7543a4e84b8759c58f71db0d93054bb7d49
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libsepol/libsepol-dev_3.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libsepol/libsepol-dev_3.5-2_loong64.deb
     digest: cd6de58ec8972c1be0f4028a31b7b94d8079bd1c0bb6af78c21ab1c1a0b245a2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_loong64.deb
     digest: 9667bac75f00cdf47520a2ec5d444bcafb4c8eb3e13efdf86218f5c69d68652b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libsodium/libsodium23_1.0.18-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libsodium/libsodium23_1.0.18-1_loong64.deb
     digest: 967fe90420e1c2608209f23f3a959adc2a3395203139559ef52a957bde15123a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
     digest: 760ec85164e31b757b0e46274b5a1eafe5a6ce53ccd0e1c4c1d7e5338e93c31e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_loong64.deb
     digest: e8619448ff773a2ab7ad66dfb6b345f899c47601e40b3982bd5b97dc701de1c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_loong64.deb
     digest: dea4a89cee5d7d70b6143ef55501595bfa963aee8777e0f1b10f46a78dc9e578
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libssh/libssh-4_0.11.3-1_loong64.deb
-    digest: 519a314568242027475eb9425196be7a19fad611cdccab8273cd7ac9f053de85
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libssh/libssh-4_0.11.3-1deepin2_loong64.deb
+    digest: 79f234dd97b93677fa5bc853f7e8a9e01c1768be60814f1aafb365768472597a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
     digest: d5528cf8ef1dcf19b1b3245d894851bbddc35132ef3fd22e8c399fd5af91a514
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin9_loong64.deb
-    digest: 949ed473270db480c09c1a427b74c2818ca01565c26b1eb386a810badaf46867
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/ffmpeg/libswscale7_6.1.5-0deepin3_loong64.deb
+    digest: 11a66f68b38d3643c438c1c1bb9b422169c4b97a9cbb513b31152779c65d7f28
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
     digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tiff/libtiff-dev_4.7.1-1deepin1_loong64.deb
-    digest: bb264461c5722bcf18a18b146ac9e02670e2f9dfce43dc43b090f4d1396ce1ba
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tiff/libtiff-dev_4.7.1-2_loong64.deb
+    digest: 6efd6595c3f17e5cae50a54430bf0d23b01855de0cdbe014c7010471dcd759f0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tiff/libtiffxx6_4.7.1-1deepin1_loong64.deb
-    digest: 20bcf3048fe9af47b6d7241a5f00e2cc1e5a844d1087c2cde4cda0cc2cb6e8ca
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tiff/libtiffxx6_4.7.1-2_loong64.deb
+    digest: 8d8f2f8c981dd1d04c6ed9ffda9a6fa75d564adcfb26fff969959b295720039e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libt/libtomcrypt/libtomcrypt1_1.18.2-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libt/libtomcrypt/libtomcrypt1_1.18.2-5_loong64.deb
     digest: 85e1e7482f2e1c928984391c424de9d81262ef9ad9535a1a5675eceb4dbe1830
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_loong64.deb
     digest: db75255d3c07f0d76e854af80a1a6090e023a5bba421ba75781bb669cf85a3ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
     digest: b2217959e0d34e5ce86a75b82acb235e1b887696044937815544c576c7abc9a7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/systemd/libudev-dev_255.2-4deepin25_loong64.deb
-    digest: 2ade21008fa24badf7c88fe545c96223c8cba29e252e048bd1e1856cae0c5b8b
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/systemd/libudev-dev_255.2-4deepin31_loong64.deb
+    digest: b3b26ee63e2afcd84db01eea4e3b08dee0dc085b2a23fd4fda83d96f29cdf3dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libu/libudfread/libudfread0_1.1.2-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libu/libudfread/libudfread0_1.1.2-1_loong64.deb
     digest: 52fe8c374d5b0f18d538139bb314839f707a1ee6da3090d411fb9c2aa9c93e49
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_loong64.deb
     digest: ee8791150f1bfe803c6dc3cbbb699a5f6db83f9acea98d0d7af33db8cc50d929
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_loong64.deb
     digest: f85518b7ab894cce4194fa481c391a70ef19c368aa8bf8b755b2927ca1636a60
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwacom/libwacom-dev_1.12-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwacom/libwacom-dev_1.12-1_loong64.deb
     digest: 80b9f218239d0521b8c10264860dbf34673b210b56e82ee01ce149a997c57a0a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwacom/libwacom2_1.12-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwacom/libwacom2_1.12-1_loong64.deb
     digest: 87c13b7db15b7c19111c5af081825d48550cd48c351e3c5ddfac976939bd67b1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/w/wayland/libwayland-bin_1.23.1-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/w/wayland/libwayland-bin_1.23.1-3_loong64.deb
     digest: 82dc01f90ca12bba758c00e7591bb7423859729e15c55b9b7de7a066d82a0a53
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/w/wayland/libwayland-dev_1.23.1-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/w/wayland/libwayland-dev_1.23.1-3_loong64.deb
     digest: 74aa1a5380f582d3fa512b1e129fd02fc7adc739766f19561c369652e7024458
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebm/libwebm1_1.0.0.31-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebm/libwebm1_1.0.0.31-1_loong64.deb
     digest: e94dcc495430d1a7cbe0c2130043ef0db8037519e7d82550d5b62e9fbfe9959c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_loong64.deb
     digest: d1393a8e0ee0c5e7110a47cd729f042ac19b418bc2560f4fcb330ff1addddada
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_loong64.deb
     digest: 6d33f9002478ee47a87b1906776df767e1248a29ff07c07e03aa44980d5326ef
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libx11/libx11-dev_1.8.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libx11/libx11-dev_1.8.7-1_loong64.deb
     digest: 9ff2157ecf2cb67c552cb49d624b32ab2393991a184e5151b233288c9a71113d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxau/libxau-dev_1.0.9-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxau/libxau-dev_1.0.9-1_loong64.deb
     digest: 15f907de0f88e9aac91b9fca3c609de2330cfe0c847b91d73ed5f3e2c4d098f7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxcb/libxcb1-dev_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxcb/libxcb1-dev_1.15-1_loong64.deb
     digest: 3d4b82cd16df0487be74f8f9f79d27fd7b0c5252c2a1c7bd2e03fa6453059728
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_loong64.deb
     digest: 389ba314f478942db7167a50aa9682dfdcbd01cccd82eeac649bd9744731aa89
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_loong64.deb
     digest: ba47dce288d90726795169d45ddf9b07f57c9391776ab2a4833ac26fe01a9c90
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/liby/libyuv/libyuv0_0.0.1888.20240710-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/liby/libyuv/libyuv0_0.0.1888.20240710-3_loong64.deb
     digest: 5db04094a96e73a685b42d380eea7a3f3b84feeb02d941531246ecf45345d6fe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/z/zeromq3/libzmq5_4.3.5-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/z/zeromq3/libzmq5_4.3.5-1_loong64.deb
     digest: ea9300e3470746654e2977f1f42d4577d502625781cdf053bea7aeff012ea17b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_loong64.deb
     digest: 542cb13caf60619314815e4a117fb1e39c3540a241aa52a34fb9cc7b4717f08e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
     digest: 300cb587a7919079edbafd58ca6c5d82ec6783aff34e3f6ccb8c5f4f170c8a5d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/lsb/lsb-base_11.6_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/lsb/lsb-base_11.6_all.deb
     digest: f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_loong64.deb
     digest: a6b376c2fd149cc6cabd93cd94dea5c9793fe8e9b9773c22bb9a12812ac52cf4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/make-dfsg/make_4.4.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/make-dfsg/make_4.4.1-1_loong64.deb
     digest: 549a2844f1ba5051fd3be57714c0e2498054ebf269ecfe235e532a0b363e4f8d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
     digest: 848333f2b40b586ecf8f0db2b6127398d0423867e689937c4427ab15570e5581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
     digest: 729d9b051d2dcda0d0bf51fee21d3b685093314a0b2283926f1eb11f937cb04c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/patch/patch_2.8-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/patch/patch_2.8-2_loong64.deb
     digest: 96dd75e1b9172451e8876729a534d1f7a4a3b36476c849aec10309973c6bf44d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_loong64.deb
     digest: 5a57a719ad9fa99d70119cfdaa3dfbc94b19c96a1cd183188125395845bb5b76
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pkgconf/pkgconf_2.5.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pkgconf/pkgconf_2.5.1-4_loong64.deb
     digest: 649c5d434ae0019a221b37d0f3e28a7a4c1b94e83e54f99a2e0432f833dbaad7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
     digest: 4b0fffc886401daa9acfb53e2b190528e3fad37a49b989c4fae6715004fda41e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
     digest: 0287e6d08e13e90c9fb8672adc90fd30703e8f4911da23cf0025e7e1d6101533
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin24_loong64.deb
     digest: b10a5e2c5c516c08219915fb96264ca59ad5a1c3a50c1cd7f6b4a072bb9f7649
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 93100c06c1fb0bdd64645ed2ede2925932b54b837e0aa6e48fed77aa99bf10ed
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 3661fc24e637a91f0d3581792adceb8bcd0326cfea9d7b732ea3f3c0f0b9b95f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 1fd6b6a904cacb4c5370e66f973eb25b02265d6270d2c4a568b6590bf9de3a5c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 62ff2359e51f5ce8513ba932701b013d0c6c2107452107b2e1a4c0be0f112f60
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin12_loong64.deb
     digest: a79e96604b3f2e4e9daa406697c02531132005b9edc420ab863f2ad2216b1a41
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 4e32e1058ff7ca5d79fa4800ee59548ae8dab3e20c2863585514acd20f1d415f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin12_loong64.deb
     digest: dbac80a48dbbce41c9397b8588e4255cad9d2d6e2177b41fe80341db00b26c99
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 24b30cb9a1f557783f1ce8936c501a5988a3b918930159113c8e92784a886ddb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 1f26803a0e93179e5fadbf0a4ee2b7612d1a4b7a044d4597d425181668e6de8e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 77e8191b5c6464d697ca305ad6536bdfe2def9ad27947566ce3295fc22dffb20
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_loong64.deb
     digest: ccfaec5003e238ac01b62089ee0f4c52ba30e9ef5370c3afa17e3cf7ee6bb318
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin12_loong64.deb
     digest: e093d545f03c06e227bbde7383d3f91752782cebe04d46e7897a4f6596a6d321
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_loong64.deb
     digest: 43df515525771e1c6d23246fa728102c60a6fa6ceb37769bf3903b190b50f819
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_loong64.deb
     digest: f9530e42280535cf1f08732b4a307c112baa3820b4bd185bce1577d20eaf6aa1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 0d413d5e8755474155ae5f850f41fe675683330232033366129bba5e76283e7b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin12_loong64.deb
     digest: a155dc306b65d796fd5b83b8168a87de282d3512b7ce4615fa5162e850bdd8dd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 63fb9ba07f26c6b40933113810c2c275622b568d51afe72dffdf262d19fc9afe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 5980804e10dc09a2635a5dfadc1b5a081643951e4aba92deb4c0b9db9f93e89c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.44.1_loong64.deb
-    digest: db4e8c6688e0d54d3a965eb3c5d4beb78ee5f439fe7768af1328d8bdd3d4f93d
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.45-1_loong64.deb
+    digest: aa99abe183bba98c15642d2450bcf73e9cf07f24ab735aa2a78ee755560ba0c8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin12_loong64.deb
     digest: f5d0ca7f23daee3ed9268fddd87cd964f63890a3c9531df3cd4b43da3a8a5aa3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 8daa9d64d6edaa190e42481bc7e9ac41316a1446310c9b83cd3666a5492ca929
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin12_loong64.deb
     digest: c150bf20fb379111b9652e645ba8f3fff6d381ac0a19a30de55f3a9a3c9c8da1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin12_loong64.deb
     digest: e64c867b0147c713933d2b54776afe65b3af9389db0b1e797d3af7a049ee6c12
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 8d98667c460dc4f93c600438b25ca1d4322977c42cdd3a8e4ed96ab704970b29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 57c8c4c3a0aeb500abd5d862f78e8fcdb9fbcb59e2a095261a7346819d2fe6cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 8b6aca0c7b71ceca9d140dc1f746efcf5efc05e8034db2be7c34e418ed07b56e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin12_loong64.deb
     digest: aee8c4d47fa62a2d1e2f65ce1bd5e9703afce67caf04c41524640cdbf85a4d09
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin12_loong64.deb
     digest: eb6fc503b8be02b67fef0c7b65af655c3fbf5f9e007dad31c8003879ef3b7c1b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin12_loong64.deb
     digest: c35a0a1fe32e39b7d4d7071a4fd91aeb41c66df5b9293c5964bffebfc07abb3f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin12_loong64.deb
     digest: b9a71a2acb099811d6b90468183cb7d7c05f975647ab01daec88c7682d3eb437
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_loong64.deb
     digest: ed0e44c516e67bda0898057181b8a1c8c75dd729fdad49961e47b0d44bc9a5f6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 96334716daf7ffa73655146faef9bff4f44d659ce699f635ee5a974306378170
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin12_loong64.deb
     digest: ba51691da1eea52374858155c4155b427d9facfb8de6c836dc4593d86c4e8067
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_loong64.deb
     digest: d3e7911d9c70e0095aff698f109dc879c5e41606bd7feb91d6eb0ae6d9e72753
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin10_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin10_loong64.deb
     digest: 6994b7bffe4234d24c656c5d691b5688c05e5dded5359cdaa706b6afb752ad43
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin10_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin10_loong64.deb
     digest: e4b815f07f2bacdc8e6a989fa7ce3663dd7cdd04e91098546d7a7c93bd9ace9d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 6ff27e89ef0526d00b5a34ceb52e71808907c7ffcb284e896aa2991672959745
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_loong64.deb
     digest: 663ebb93a2d4c641de8c11920366c7b697027bfd35d3e41ca65b514016234b5f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin24_loong64.deb
     digest: e88707781e631f95f67996e75498d41a847cc80b1304ad2948d5df110f7ea275
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 0467acd3c74cabb1b43e3bf153ab476e3428379501e291d5ee4736164fb8d505
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 177ea3eb52c1195f24be66c495076e1b3a23104833fb50a5bddd06e3b3155e2d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 2b9e88afcf9d78b5f47d4eff681eacbc4371b038b6f20fc916abe384be17fd86
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 3f0c6f7a34e31cadd5a7e3fc22228aa472d463b32081201b9e6717fdcf33403a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 6b3b5e61af81329f8bed84c499916a244dc0e8797dc45d66c96ae1bb5366a3ef
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
     digest: ec3065e7d3127545cbb6dfe84c2d9f7e38b015a368033c1b8c67d955f8001b95
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 0bf727a48631a496258f7ccc6852b0987f19eb8331e933d476aa8c6a95f3964d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_loong64.deb
     digest: 53a2079f81a2fdfbc7662bab8e901eadc88d129908f90e7ab759bcf6c4f74c29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
     digest: 91e20e6b2f68393e3b4764b9f57d55ac495174485239a607f994ef1aee08c459
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_loong64.deb
     digest: b1199d84256f297e6dd6d3b3cfe173285df461da56b10742c9dcae91c616675a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 0f4947e41088840bb2d6f8a0fe37f585836e8dd4f6375bf9ee014c4512bcb6e8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin12_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin12_loong64.deb
     digest: 120bf33d41e88611d37818e945c771face5fa5e6b3aae2d81666260240453af1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin24_loong64.deb
     digest: 8e7122ea65f8fe463d1aea0c6fa553614bc7f69ddcb83ccb2f72dcaea36bed3e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_loong64.deb
     digest: 366fe25e1aa641f31c261a422cd578724b47e3336d43a913e24a3d0c3d18c1a2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_loong64.deb
     digest: f7d6d0e11fea53ada98657b4a547a7758ba1fa1e0aefe109b9b1605a51ce0bb1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_loong64.deb
     digest: 0b390252dfa1e2666f40d6ab8fb75535169d22b21879c19a67f9cda4efd1432c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_loong64.deb
     digest: ccc3ca5bf5149ae18468a0791515a746e4c6d4839e63547314786d7b3977ee4f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_loong64.deb
     digest: 32fa2629e5a6815dcefe7e945cd4b4ccc00712bd72cb9c79501998cb6e39a4dc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_loong64.deb
     digest: 4c27718be3d7bb75aeb12a2b6ffa4764e4600edb6b06cf3f31f45f99c70b6fcb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_loong64.deb
     digest: b41b3f13bf4aecc868c876dab50bac5adb4471ccf989ae8641a2fdc7a83878b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_loong64.deb
     digest: 46026db29c9ff37a25638150ed457ef56d8a29b5c973ba386ae44ff0ec30ba03
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
     digest: dbfa88dae0e66fa60e6558fa80242bb78be8dec5b37ea449f85826b1b48cf25c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin10_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin10_loong64.deb
     digest: 1d7ed4ce0f155a39a659c8e57aa4d08ca87de1bdd4aeb00295856ff0ec0e20d3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin10_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin10_loong64.deb
     digest: 16e7123cfd8b56728005fb235c9e30f2d628469a6af4a227cc6b374facb8681e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin10_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin10_loong64.deb
     digest: f03971c922b6a6fd930d40678bf67fb4b45538ee0fc7b8382dc291a8c4fbef17
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin10_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin10_loong64.deb
     digest: df895de8c1d3168d6f9f196f301820914e62136550af5dde22ed2a5e620c66e2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
     digest: e70bbe5b35aa1009f8d3e8d58634052977864bad1d854230add6758ef238b1bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin24_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin24_loong64.deb
     digest: ccf2d767a5817da737d6639d781a8577f9156d70bb09d97099ded38965be5c0b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
     digest: aae8ac2b6d3198d297d430cdb97e556365be2ff46d06525008ce071d97ac69c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/uos-license-content/uos-license-content_2.0.7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/uos-license-content/uos-license-content_2.0.7_loong64.deb
     digest: 75df8322b47f7dd8d65779f2c2ef1336820a2ad6af0f63d4b3e4628cb8e74d15
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_loong64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_loong64.deb
     digest: c4cb5f3fab879a163726c64a88e324efd42310194291143a3c3c868fc5f05453
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
-    digest: b40d74ed9b2014e3a3bcb7c6121a17e16424d0ef19c9ee1aef977b7460b1b1b6
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.2-1deepin2_loong64.deb
+    digest: b429b71c963c4877dd9dc484e07624b08b0b61fe7ee24fb5a62e729b66620efe

--- a/mips64/linglong.yaml
+++ b/mips64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 6.7.0.44
+  version: 
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2

--- a/riscv64/linglong.yaml
+++ b/riscv64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 6.7.0.44
+  version: 
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2
@@ -13,7 +13,7 @@ build: |
   bash -e build.bash
 
 sources:
-  # linglong:gen_deb_source sources riscv64 http://10.20.64.92:8080/crimson_runtime/stable_20260708 stable main
+  # linglong:gen_deb_source sources riscv64 http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3 stable main
   # source package qt6-base
   # linglong:gen_deb_source install libqt6concurrent6
   # linglong:gen_deb_source install libqt6core6
@@ -179,818 +179,818 @@ sources:
   # source package uos-license-content
   # linglong:gen_deb_source install uos-license-content
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_riscv64.deb
     digest: f1b76a14359bdebd460533f8908cfd0c2137e4a7d596c7701dc758ae6989b8bd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/b/binutils/binutils-riscv64-linux-gnu_2.41-6deepin11_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/b/binutils/binutils-riscv64-linux-gnu_2.41-6deepin11_riscv64.deb
     digest: 479bf86da7782a05c01a92e2180f1d314faac51425d2eb0480bce6ab2bb09716
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dbus-broker/dbus-broker_29-3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dbus-broker/dbus-broker_29-3_riscv64.deb
     digest: e7f386e7dfed77d33306e3008eccf0613d50081f1beec6e5a2bc02a3cc7aa83a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt5integration/dde-qt6integration_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt5integration/dde-qt6integration_6.7.44_riscv64.deb
     digest: b639489a1402788782ff2941780ba52cfb4149eec33c0f14e976b9156bfdd28c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dde-qt5platform-plugins/dde-qt6xcb-plugin_6.7.44_riscv64.deb
     digest: f2ee43fdb10449a0536d723f80300b98d84cbb117eea4a2bc1903d374aa51d4d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/deepin-shortcut-viewer/deepin-shortcut-viewer_5.5.6_riscv64.deb
     digest: 2c2353029b346104c05adc2942116cfcc467876d22d28d888a1a8eb91bf2ef4d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_riscv64.deb
     digest: 95ae06220f02881737d6ec21794e03e1c930611f4eaf689b8603ea2163fb1cd7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dpkg/dpkg-dev_1.22.6deepin10_all.deb
     digest: ad27e359a1fe3485255ce3c17eab99ae42ce1aa03acd67e45a2751710dc463c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.44.1_riscv64.deb
-    digest: 75ee089649b0741b18530cac89b3c11723ea0d6edd62a05e6d40738e2e7da4bf
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/dtk6-exhibition_6.7.44.2_riscv64.deb
+    digest: fa7f4921937e3e5038d24efb842f5d99e92bab96c805622bcdc2269a015d6a9c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.9-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/fcitx5-frontend-qt6_5.1.9-1_riscv64.deb
     digest: 00514615da4b6180c6707c624cb5b1f0ac1cbc0149560f01351767d3daa8f72f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/firebird4.0/firebird4.0-common-doc_4.0.5.3140.ds6-17_all.deb
     digest: fafd08c872d1279aa0bde2e0bdf40a57721961934c0593352b6a2c551aa232a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/firebird4.0/firebird4.0-common_4.0.5.3140.ds6-17_all.deb
     digest: ef932bad267f9d4d49c0c376ae1d0fc1a9b595054f8450d42b2a0d6621bc7084
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_riscv64.deb
     digest: 1cec08f8cadaffb74c0e260f237c968fa1ca329bdfa681063f4c52e0c2107e43
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin9_riscv64.deb
-    digest: feecee2f5d9d15b34249aaf73011daa65b86bcbca6888b83bb74878f3388a11c
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/ffmpeg/libavformat60_6.1.5-0deepin3_riscv64.deb
+    digest: ce15b315eeb82babf33c707cbc240472a3d18b70eb2471b21f2c8c1719cd3a3e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libb/libb2/libb2-1_0.98.1-1.1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libb/libb2/libb2-1_0.98.1-1.1_riscv64.deb
     digest: 9b60cd9369a923a237dffba4b3c9767c9b88a84fa898352082f84e02db055a2a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin9_riscv64.deb
     digest: a5078ebd6c36aace2fcf1a1046a3b6385cd8fce4162de67a9fcac55880cbd372
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_riscv64.deb
     digest: e39a11eb2cd82766cd4f9162f938e313a640b9b172877be2a3c0cfa857262ec4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/b/brotli/libbrotli-dev_1.1.0-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/b/brotli/libbrotli-dev_1.1.0-2_riscv64.deb
     digest: 0039fef95d65a74e5e581c5a77167e6ea43084f9bc0dec017667bfe408869ccb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_riscv64.deb
     digest: fc087f345850b721d5a397b5bf2a0a29bf35871c8a05ab372f9a963531798f37
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/capstone/libcapstone5_5.0.3-1_riscv64.deb
-    digest: 524f15ff7c479cd10a82752aa838c4d89a2711da9bbab1afacd2590bc9b12337
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/capstone/libcapstone5_5.0.3-1deepin1_riscv64.deb
+    digest: cfc09146dce4d562d7409ef75d576161345acd6a08ce879ce459e8676ce41829
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_riscv64.deb
     digest: a0be217eeb06edcfddf3d5384e61f151f91b3b5b7b9339dc8349a6687ede60ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/cjson/libcjson1_1.7.18-3.1deepin1_riscv64.deb
     digest: f56f75b4bad909e7170ec44927dd8553b132f442eeb40e986b3ea660b3476581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin7_riscv64.deb
     digest: 91a2abb2be0e0f423643536fc958ff46dea1b8fc45eb2dc54ab16db38b3f06a6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin7_riscv64.deb
     digest: d5fc4ccb1133cfaf401dea3d21ab85bffb4eb9a77af882934cf849183e3b03cf
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/cups/libcups2-dev_2.4.16-1deepin4_riscv64.deb
     digest: edad961bd8a8c184eb5274535d374c71ea0884bd5b6977ed8102bf26bc010374
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/c/cups/libcupsimage2-dev_2.4.16-1deepin4_riscv64.deb
     digest: b7170b1debf169971267e294a69c056bd03a312e4bba4d14608f2707cde4e6ba
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libd/libdeflate/libdeflate-dev_1.23-2_riscv64.deb
     digest: 965346a9a625404560bc6c4811eb8c16e7fbec47e762e5ddc921dcfa9072ff00
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_riscv64.deb
     digest: 0a841743761adea5fb895e78f6976412cb2db4a14cd272b993d22f3a1b5779ac
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin10_all.deb
     digest: 5ac1e65112a190dfca99abf002e3e3f0ee033919b7b65cef5e3637ff1821cc9b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcore/libdtk6core-bin_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcore/libdtk6core-bin_6.7.44_riscv64.deb
     digest: e945cba8dda6bc52c367f152a54a84ae164ea9ddc768201d3a3c602fa838d8c5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcore/libdtk6core-dev_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcore/libdtk6core-dev_6.7.44_riscv64.deb
     digest: 9cb738f3c169c916faafd1ea06edf3a641a1ef9edc6bc82ffad44187b48fadab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcore/libdtk6core_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcore/libdtk6core_6.7.44_riscv64.deb
     digest: dde39acc78c064829563b6c38f5b0c4c7fbf22190e640c9c0c7f9b21457c15cb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.44.1_riscv64.deb
-    digest: 8d895d678f2b36c0b93d624b088f3ee6a570d7a8b593f3b637d5470de724e1dd
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/libdtk6declarative-dev_6.7.44.2_riscv64.deb
+    digest: 0b8e9a33b4b91c39f911f5d5b3236706ba8fd8a14ed07be583e14fc429ef8f09
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.44.1_riscv64.deb
-    digest: 99a73d30b0bae2e9f6f48e0e6d6044d16d2e2f6e119c9200a57807f4076110cd
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/libdtk6declarative_6.7.44.2_riscv64.deb
+    digest: 5ad4849d012912eb8da1467c390c5b837563f3968cab0f977b1ca6c84618b01c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkgui/libdtk6gui-bin_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkgui/libdtk6gui-bin_6.7.44_riscv64.deb
     digest: 9531f3b53dd70879121f30a0778334e4066ce1844e763f13c36d528358df67a3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkgui/libdtk6gui-dev_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkgui/libdtk6gui-dev_6.7.44_riscv64.deb
     digest: d01280e091f569161ff00999e538c6134569ce7bd6cc1dfb4aa7cab8e4ac1865
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkgui/libdtk6gui_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkgui/libdtk6gui_6.7.44_riscv64.deb
     digest: 5bdeece84e28307673798afb53048890a971db5ddb2969337f91b4c96ddb32a4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtklog/libdtk6log-dev_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtklog/libdtk6log-dev_6.7.44_riscv64.deb
     digest: fae47f921162e2b0ff407d1659ea3e04c92e99d45ca4690b57cfd96876597d9f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtklog/libdtk6log_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtklog/libdtk6log_6.7.44_riscv64.deb
     digest: e213e3c699d925bfbd4dfaf413e25ada5f6f22c711dcc37f078a311566ff3f72
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkwidget/libdtk6widget-bin_6.7.44_riscv64.deb
     digest: b2d3bbaeb53ee118dcf4858ed87625222a5f304293880287b03ccfdd9b6df3cd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkwidget/libdtk6widget-dev_6.7.44_riscv64.deb
     digest: ad8fc29d609a608151fce07df66e8fff48a6224fa96dc9dc46f7e3fbdc14a97c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkwidget/libdtk6widget_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkwidget/libdtk6widget_6.7.44_riscv64.deb
     digest: a24aa0d9094519914cc9cb35de43ab8b4853b275c1532ec5317e184878646cd4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcommon/libdtkcommon-dev_6.7.44_riscv64.deb
     digest: 0059180e37e54f2693abca985808eb8b014c663bda3865831695c562ffc46d94
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkcommon/libdtkdata_6.7.44_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkcommon/libdtkdata_6.7.44_riscv64.deb
     digest: d8436bc2713436c0fa906f79c4126bf59ef4a5020957facf478c80849963cfe9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libe/libevdev/libevdev-dev_1.13.4+dfsg-1_riscv64.deb
     digest: 61bae1d6340bcc10ce08f084937caee62c342902720aae7b921cf9a6130de780
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libe/libevdev/libevdev2_1.13.4+dfsg-1_riscv64.deb
     digest: 469af5334d45efc0a186ecce22d907c78e813ccfa6fd9a103f96a6054a8b2d70
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/e/expat/libexpat1-dev_2.7.4-1_riscv64.deb
-    digest: 4ddc3ae72bc2e5f2e19df86047e7a29e9bdb51c79f32c56e3e4f322429b08b80
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/e/expat/libexpat1-dev_2.8.0-2_riscv64.deb
+    digest: 957fd3a24d91835507042b1baf6df099d20075069e3e6274ba76169680cef04f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/firebird4.0/libfbclient2_4.0.5.3140.ds6-17_riscv64.deb
     digest: 6aea8991fecc5f08335f1db6a4f64c8a417f3fc10d4ab20f593f408c5e4fc1d7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.9-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/libfcitx5-qt-data_5.1.9-1_all.deb
     digest: 095f6c357e994b15d51e9cf85722cbdf80f821a8ba2e5b2310fb9a40bb2529b7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.9-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/libfcitx5-qt6-1_5.1.9-1_riscv64.deb
     digest: 301f9d9e66fd35677fff694318fc7c326f4ee49597171dcf4f42cf380d3ef722
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.9-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5-qt/libfcitx5-qt6-dev_5.1.9-1_riscv64.deb
     digest: 1f4648c7c2913b20070e2e5a383ae0185863d16a9761844a970b8d57753126d4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin1_riscv64.deb
-    digest: bd1bd300c7d66f1deff7b28071e37d2df5928e0bf567334c698a37323a7dfc52
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fcitx5/libfcitx5utils2_5.1.12-2deepin6_riscv64.deb
+    digest: 660f0620ec650c982d316b9d15898001c24094ed14427b8265b44e1985b5c9db
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libf/libffi/libffi-dev_3.4.6-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libf/libffi/libffi-dev_3.4.6-1_riscv64.deb
     digest: 2ea6331695ab1f0ad252a1c73350a41b1bf2d7539d26d8fb76eddbbb90d73007
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/flite/libflite1_2.2-7_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/flite/libflite1_2.2-7_riscv64.deb
     digest: b18834cae56b5af7f78fd8315c8632f87b5e947ca66eb02c008820463911bf95
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin1_riscv64.deb
     digest: 6d0d5c4301dc43c2d6f688370fd07d7e0aa1f04969fce0328014e1e8f14a8ab4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/fontconfig/libfontconfig-dev_2.17.1-5_riscv64.deb
     digest: 3e58a7e601e06a907f752eed448fc16440fce4352e9181b49a88d0af648e8934
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin2_riscv64.deb
     digest: bcc3c9bfedc0fb5f0df2becc6ef03ca81c62347a6bffb254e79df0ab0e3c60c0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin4_riscv64.deb
     digest: 4593b7d771255ea0808390723ae350b20a711423207bcf3ac12c5baae9859c4e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_riscv64.deb
     digest: 3d289417019ad68240a262ced9658772f5198b3b4454054f77297a01cbd87400
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin4_riscv64.deb
     digest: b48a1513d581e26596168908875366aa9a3584385f88cf42cc54044d126e40cc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin4_riscv64.deb
     digest: a154c188f6dce87b66ccd625a03124f0fb58af27a79cf6781d51d652bb781fb8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_riscv64.deb
     digest: 104c18d67f0f4e04452473b93619c3849a32902f2a9e18b41e0589031ef57494
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_riscv64.deb
     digest: 1301a6b03cfb9b2efd7fb39624c2d5449e1753ac8a4382317365cc8556f86c32
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.13-0deepin1_riscv64.deb
     digest: cdc83f9ab8b3227cbca9b4b1ca4768cc161409e7561bfe581c7959c11436486a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libgudev/libgudev-1.0-0_238-6_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libgudev/libgudev-1.0-0_238-6_riscv64.deb
     digest: 3389f32ffe956e09ffaf206cf84e75057f040c8288cfe5ad2d5ccba6d9710600
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_riscv64.deb
     digest: 1db717bbca670d9f5140f969fc7d9f66a1e6c61b1c01fd8e7c5b75e093352cd2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_riscv64.deb
     digest: cbbbb704783dd2b93f31e9307db80671803cd1581018558255e9b78b1d7b99ca
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin5_riscv64.deb
     digest: 1cb29ca790611550ef26e00fce2f9dd0c33c23930832bc10e4661600910e820d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin5_riscv64.deb
     digest: e3e702fea1ff6ebb23f5645e4d2cd984dcce8e0207c09ea2ece06d3236ebe205
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libi/libinput/libinput10_1.26.0-1deepin5_riscv64.deb
     digest: 4b87cd278c182c5995d396455260939f8766422eb989b7819388d0e7917261b4
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_riscv64.deb
     digest: 7ebac4161b24d7bb2db004047bed847bac5fd6191e854ebd64349734d92543fb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_riscv64.deb
     digest: 490f6f16b226a94447b2da2a2d289d57a89fa06d21aab6b49f80505abe2f5902
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_riscv64.deb
     digest: 57d3d5bc426b2f9ab046f0fbe7f385a6f54153021d7e2a8f3bdcd27c5abc7723
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_riscv64.deb
     digest: 4c6661cedcd1cdd6a285b48761b97e4c22970c1a0a1daf00faa8a61a117e823f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_riscv64.deb
     digest: 2553dd1c07771adcbd55bbd87bd6142ca3f7266f65b5107a40676cd1f715207f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_riscv64.deb
     digest: 209f73ebc494ce3fd0809c406b75a3e65e563e35f2619be5835be522fa866963
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mariadb/libmariadb3_11.8.1-4deepin1_riscv64.deb
     digest: 7a99cef667bcc641ff456334287c46753be3a05839a82ac3e2ef6da1fb514a7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mbedtls/libmbedcrypto7_2.28.8-1deepin1_riscv64.deb
     digest: fb68c843d5dcd1bef05cb7b6f2e7398972f789826cf98e0f4aa229576d0fcb8b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/md4c/libmd4c0_0.4.8-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/md4c/libmd4c0_0.4.8-1_riscv64.deb
     digest: f3af7c8797caceeb57072524fb06b52f23fd3b2954f8f1e8d72f04f40d7627e1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_riscv64.deb
     digest: c99c7c1164619af8b2138b1d68fa481edb04728397868e78b527a443d9401b88
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin9_riscv64.deb
     digest: f99105e98142dd5e91e338c3538bb424d9173fd3443aeffe73b7096678b39350
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_riscv64.deb
     digest: 0accda97e1ccc619723c9eadbaf5b7a5a443b46b203649cba6071c57385bbdb5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mtdev/libmtdev1_1.1.6-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mtdev/libmtdev1_1.1.6-1_riscv64.deb
     digest: baedacaa7999a3ba817b97ce117b09048f68ae40238e1b0fd343681640ed82da
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_riscv64.deb
     digest: 61a1368c73406a2125c88edbf972ec08f77700e52351f22ec72a8e640513078a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libn/libnumber-compare-perl/libnumber-compare-perl_0.03-2_all.deb
     digest: c37a63d53d982b9596a8e498e9ef95cf07cc245eaa2a8df8fc8546e82511fa7c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/unixodbc/libodbc1_2.3.6-0.1-deepin1_riscv64.deb
     digest: d8638306155067a6d66feb139f45d6fca7cd03dc8dc27a00321c43fab48550df
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_riscv64.deb
     digest: 7291074795517ad3711ce1a2691b68b803e84c4452f28b6e109c4818baa78a86
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_riscv64.deb
     digest: ab0a9e08eacdfb316182c7db7fadc82e2e9cadf45a203aa61475ca4564ec660e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pcre2/libpcre2-32-0_10.46-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pcre2/libpcre2-32-0_10.46-1_riscv64.deb
     digest: 48d3ef610b214672acdc40b609ab5fe459f68c45d0f9fe985f8c24b9aaa4bc76
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pcre2/libpcre2-dev_10.46-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pcre2/libpcre2-dev_10.46-1_riscv64.deb
     digest: d9083777540d4eb86a436060f100e4138f54ed940ad9ae6c49b7897eef3a6a60
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pcre2/libpcre2-posix3_10.46-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pcre2/libpcre2-posix3_10.46-1_riscv64.deb
     digest: 40f61af8aa4087e05d41ce1224d9ce011a424eea13ef32a646365230b14f646e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_riscv64.deb
     digest: 2a272b6869476a9dd48df8986ecd3d9cf745ff08ef4a48f99ba0ae91460ebbb2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pkgconf/libpkgconf7_2.5.1-4_riscv64.deb
     digest: 409554b8b3589b8431f12e167d3961610797d15e7e52ad24ec8c75b9d9f01984
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libp/libpng1.6/libpng-dev_1.6.53-1deepin5_riscv64.deb
     digest: be96c321bd1781aa566d6f97f1f0cca1421f059a38fda6f0250733d9b0bc360e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/postgresql-16/libpq5_16.3-1_riscv64.deb
-    digest: b3c0061a1e767a271b1a9bd723a73d1b0193ccd3a5216992afafe3d5ebcbd199
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/postgresql-16/libpq5_16.4-3deepin1_riscv64.deb
+    digest: dbb80c327a34d741dff3d96886fb5fb64ad64c664d50f52329354481538e9aa8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_riscv64.deb
     digest: 634a64854472f76ca29c54914c400f911fd200b7b1cbca0522acccdccf697b7e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 2fcdcdf7559b67eecff64c2e3fd9c0a7ed252817cc5c1cee30842f106a346b82
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_riscv64.deb
     digest: 44d8c97b5926aa78d03b46f126e3a506b28e1c30324773455e40d3bf0791812c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: ddbda9e74643b5b47cfe744419b9d48b7748d68c67b90e3fb7116d376f80cdc6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 0a87c366fbdb32ede97e29649e385eb2f33baf7e861606e1ad15700b33afba9d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_riscv64.deb
     digest: 8f8983f0776b0e71d752807fa75e2cdf8bd97db8997fee1a292c4c125dbb62ff
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_riscv64.deb
     digest: 94f87d57050a627e6cc3924b5a4f13d2e583ea77dc4448c34c2a717256210117
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 688aa534da61ef0521b9ec91692ed32481f8d6920d29f2637449b1984d86b657
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_riscv64.deb
     digest: 65120dc4c2a84c78386021c608b79d808217f9f483e5ab558b738c249509b8d5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_riscv64.deb
     digest: 81b863f00f1c94f38308e05213b5d266fcf1107df8fe0a7b1238ae1a266e835b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_riscv64.deb
     digest: f4c1a2908bb7f965f9d2cce6852e0193b35d1dd90748986dfe839277886db7b2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 1e3985c6b4dfc0cabda9821817deae4235f48319f062ce4896364201350c780a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 461cea9089cca4dbf77a85d8a6d0ceee71af8ddd7cb08419e2daa98c63555e62
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: b5366786fc443b1f16c9dd958e033d3383ffa504061d2c863a46412b85475bf1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: c4b27b141618e22d14035b0bc9a78618cfb110e7255ac6d9a8dce3a44d02052e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 7b076b3f54fcb58316da1f24839a6f48b88c5525a71e1b91780bcba7440774bd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 309c60922cc0a2f3600d02e83d5534a6a0856bc543529cc73a004ad4e3e25beb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 92105b28d645af80206caddca29db7873df046d3230b72128fe71ddaf295e474
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-quick3d/libqt6quick3d6_6.8.0-0deepin2_riscv64.deb
     digest: 23096cd068f90f75d30d2dffb998255fce9a6116f8e73084a6792aa718ad1e0f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-quick3d/libqt6quick3druntimerender6_6.8.0-0deepin2_riscv64.deb
     digest: c3db46d63b3f455ec002f19866994f555af939f6b5cd9037a1647ef8aa174fae
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-quick3d/libqt6quick3dutils6_6.8.0-0deepin2_riscv64.deb
     digest: e8d6ca3ec477a529a9702f43491d5ee69d6505af41120e63e57690909d8dd89d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 344f81a42d59140afce0386f30d3e46dbb0bc3e35df392bd4bef764d8c9b55af
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 3190812af6e2d06f11467fa1375253078a3d3ea4e5611cb02d17837cd350d6f8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 10d52c19d9a02effe04b54d3d2c9923066a28d730a87100f6e66f2ed6a0fcf11
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: c25f0c8874f47f7978541c3390f81a6858ce22d6747e6bad886389a16e00683f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickvectorimage6_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 04b54c7b988c761aac3cc49427c4d8171cb4efef4f9ac56289eedb7349b4f75b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 6128907238361e238ea9d71c466b954de09dbd2c2272efdb51505033dc37ec7f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 5bb22ffc5b65c6d3d81088ef63ab504734e50a7508dd13adaee3176c3d8b6121
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_riscv64.deb
-    digest: 2ea67ea515a5ccbe57225f97b66a8c349d73b493b2f0356ab5367edcbbc4878f
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin2_riscv64.deb
+    digest: 8ea9c3015812f00d43ed69d5cdb2c22a45416a5d7cc03142ccb1aed07571098f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_riscv64.deb
     digest: ee60eae4cb4d4beb724ebdfac90314aa13ce4963d5292d61374719f919580d40
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-ibase_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: cfd8134a122db3b8c560ee8fc58888b237b436a282f9b0553be9dbb35630d8f7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-mysql_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 9d2adfe407115509275cf8ce4f4285d8b6c2a6c9388f98b5c9b8eb3376029047
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-odbc_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 04a63b7128f86de22dce77f16469e8f52e3fae7ef0f0981943034747fa8f891e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-psql_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: e20d632e8b8dd96aee4e87daa17e7d71380d6edffe5d29bba933b3cac355aec6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: f62877da69250313bddaf3a965bf9bc5602fb857373ef9fef24f2120f80047a6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 737234fdb83f49592fd16c448a72c1c110946d206be47978c6390c2711527fa8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin5_riscv64.deb
     digest: 31c4be6f637365f551df3227ea19c43ef2bfc612ae203abdac1f0a048415b553
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin5_riscv64.deb
     digest: e03df7a7a8cb4aa4421e9e1967e1580ae1e9dd0f86ea0e0183104fa165017b5c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 272f8b59ae0f1c63d122577c29ca1161d5577c093d2041a7c976ea0bea435ffa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/libqt6texttospeech6_6.8.0-0deepin1_riscv64.deb
     digest: 06ce9a2fb3687d3d765c94bc22ce5396c4b4c1fc877910b332fe36ec02615613
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_riscv64.deb
     digest: 56dbc795c1e137250f02f7a31f59fca5d9ef41c05ed2b6d750c6d692e0f0d542
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin10_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin10_riscv64.deb
     digest: cc78d3da47d41961f6f06268c287ec6f53d24df9406abcfff19169fc8a0564cb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin10_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/libqt6waylandcompositor6_6.8.0-0deepin10_riscv64.deb
     digest: 8d7e439c74f28832978b18cc917a1150cf22299fec168a15cd7ce2f072d89534
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 86a44e3ae0124b1516c3738172d62b9bf7babe6344667a265f1780ff3a297868
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin10_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/libqt6wlshellintegration6_6.8.0-0deepin10_riscv64.deb
     digest: b2eadc1c93e6565ff55a7f5e1c6d6dc87549d46ec4453e63c957098e25de1f02
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: fcae8f5fcbbc995dfab6ddcad102143e48f41c9c6920b6539417c858183cd8e6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_riscv64.deb
     digest: d7147fd75ba6e867a4b5150fce61f07e8479b9f02963c50bc7af87f2ee7b5168
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libr/librist/librist4_0.2.11+dfsg-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libr/librist/librist4_0.2.11+dfsg-1_riscv64.deb
     digest: 46e19c19546d84eff60048872f5445b16e72b8ec883e703ec7f236219f203a88
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_riscv64.deb
     digest: 1e7da0c01190e31c826a663e66f25e0da593cf34d6d5981049230c8454ac6cbd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libsepol/libsepol-dev_3.5-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libsepol/libsepol-dev_3.5-2_riscv64.deb
     digest: e61b8befaffd5fb6d95ebee86b3ea041fc4df4bb5c94f83a473b695bea849209
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_riscv64.deb
     digest: 37c5d5ec3a331da214055f608a31da6e7e2514b47ffe4c6abff080015ace38e7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libsodium/libsodium23_1.0.18-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libsodium/libsodium23_1.0.18-1_riscv64.deb
     digest: 30914902997307d89afd39d210e984254f3c83de8d51adce058d41cce8c01937
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_riscv64.deb
     digest: 6fb11fc06c27a21ed5189d5605a26157afccdb605bc843aff05dbb8b583642b2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/speech-dispatcher/libspeechd2_0.11.5-5_riscv64.deb
     digest: d36ce6ce1b62c930a8fbecaace0b3ef0825ba6d02348778f5e76a1cf808d2bfe
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_riscv64.deb
     digest: 7f9762d2444169e444bc4fa3614f8be9cd1093350dd41eb961c887531ceba4f7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libs/libssh/libssh-4_0.11.3-1_riscv64.deb
-    digest: 83e14ef60d6b8011a9bbebe48f69fd1bebd99f3f916180c1173b0216545d1033
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libs/libssh/libssh-4_0.11.3-1deepin2_riscv64.deb
+    digest: 5b887f74124ada0cba26f66b34767b293063228348d5cd8c545abb57a51d8972
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_riscv64.deb
     digest: bbaa03a76b6ca6f7dcd6647d8413ce29c779e43d0e8dd999ebbaa91f9f21df4f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin9_riscv64.deb
-    digest: a900893f82e76e974a0c51cc54e1420ff2f05f197c4ce3c7f2d825656051ad62
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/f/ffmpeg/libswscale7_6.1.5-0deepin3_riscv64.deb
+    digest: e52ec43e42901a091279a9ff51b5e1e0e96c2106bbf6863be9426b9bab9b2ee0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_riscv64.deb
     digest: a81767e023eda57d5528e6084da7f01ad06aef316129a4804585f95bdcfd7a37
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
     digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tiff/libtiff-dev_4.7.1-1deepin1_riscv64.deb
-    digest: 02dcb3ca9d245dbc069ae335f98224bfb39c9f2fa49876d53a26e920e6d8faf6
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tiff/libtiff-dev_4.7.1-2_riscv64.deb
+    digest: 6ee3978683315c6ee6fc2a46dc95c008c6c866f13d1eaeca7e63683009bcf1f6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tiff/libtiffxx6_4.7.1-1deepin1_riscv64.deb
-    digest: e4ab0f5d4f9b9374dae94ac8bd7739aae554f8d619832fb1fa7be3886068eb49
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tiff/libtiffxx6_4.7.1-2_riscv64.deb
+    digest: 67f099e6b0e49c4017b2de49d9890f0ef1cd3575de0c16066968021334122664
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libt/libtommath/libtommath1_1.2.0-6+deb12u1_riscv64.deb
     digest: 7f1343979eb3ca64474b735fcc48cf3fbc04126a3845e91895ae10ab2197a3b6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/t/tslib/libts0_1.22-1+rb3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/t/tslib/libts0_1.22-1+rb3_riscv64.deb
     digest: 06a0f14a72b09fcbc2eb78edcecb99e3be3e113726b3c82f86b5af16981853db
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/systemd/libudev-dev_255.2-4deepin25_riscv64.deb
-    digest: 094bbde9397e7aa068763fa1404f62af407af3ba078fab552d5d699e87c1f496
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/systemd/libudev-dev_255.2-4deepin31_riscv64.deb
+    digest: ae92b9a6a30dba7824d554f6016b2e43726d6b45cace1e6dadf74a9a4221083f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libu/libudfread/libudfread0_1.1.2-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libu/libudfread/libudfread0_1.1.2-1_riscv64.deb
     digest: 0367ec4150f43bf01bae030a9e1739f0bf8048dc8d25fd878c62a12986c95e2b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_riscv64.deb
     digest: 4bf1961ea6c45dccf1dccc41ee5a6929656ce17e4deb1412bf622e6bbc3e08bb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/v/vulkan-loader/libvulkan-dev_1.3.296.0-1_riscv64.deb
     digest: ca14c41769b5ef31000973899a08430256cf98f2348725e5428e107e487d4db1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwacom/libwacom-dev_1.12-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwacom/libwacom-dev_1.12-1_riscv64.deb
     digest: 330b8de6916b128e899604f5ffb92b25298df5098db1dcc31c98fa25aa9a79cb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwacom/libwacom2_1.12-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwacom/libwacom2_1.12-1_riscv64.deb
     digest: 498a4767e58ca9868acac5579e0bbdac1eb35ea35f419e0893b2bbf967eb0aaa
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/w/wayland/libwayland-bin_1.23.1-3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/w/wayland/libwayland-bin_1.23.1-3_riscv64.deb
     digest: dcc81c685e8c562ac778009422ac1daafbc1b7e444e2a0cdf7ec2cde870cef9e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/w/wayland/libwayland-dev_1.23.1-3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/w/wayland/libwayland-dev_1.23.1-3_riscv64.deb
     digest: 7459e34907cad410ed0e3ae782c328f73b6ff7221261dd7b6ec6980e7fff4d1f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_riscv64.deb
     digest: 7af93fd9ae41fbb58eb92e14a9af85fdfb99995ca271cac2f7931535aa7668ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_riscv64.deb
     digest: f079e4466da41aa73db79f49170916b73fd67c7682152a554c0fa08ff3b74eb3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libx11/libx11-dev_1.8.7-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libx11/libx11-dev_1.8.7-1_riscv64.deb
     digest: 9e3d4a4daf77dbd70e768ba6bfcb5d6212ee5befa887167d362cfb5d5e0e7c0b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxau/libxau-dev_1.0.9-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxau/libxau-dev_1.0.9-1_riscv64.deb
     digest: 9c56bcf34da29b6562bb6f9f2a9a2b6fabae5999f077811abce30694d38d4cf9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxcb/libxcb1-dev_1.15-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxcb/libxcb1-dev_1.15-1_riscv64.deb
     digest: 9333c28df208e905fb6c8f56e02c3287d990c4eab0510bd8afca2ac336971ac5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_riscv64.deb
     digest: 1046f66278e6bafe279590f5aa0c8020b2f0daa429479d2d78397f78568991b3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_riscv64.deb
     digest: 7f29bf0ee322ea6e30a0b5bccd80de703149d31ce9ea7a5c8e6e21f4b1f810d8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/z/zeromq3/libzmq5_4.3.5-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/z/zeromq3/libzmq5_4.3.5-1_riscv64.deb
     digest: e9c4cc06172fe4cb597a23d91538bb797322890a698357d6257a5a84a95fd7ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_riscv64.deb
     digest: 13435b1929aa7177e5807071669d3f930ca829d7a7a2e0fc38918c4693241bb0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_riscv64.deb
     digest: 5fadba4d8655ff36ad7ad19ff9e5e2d655968683690b1b707a1b85cc58a1b8ef
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/lsb/lsb-base_11.6_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/lsb/lsb-base_11.6_all.deb
     digest: f8bedd167280e76636df3a1bc023cd2906d458916c1af4c1d7912c5b971fc642
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_riscv64.deb
     digest: fdb9d744dd605097334a0bf735722ef29448fcb5a7e60651156028b4dfb3bb88
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/make-dfsg/make_4.4.1-1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/make-dfsg/make_4.4.1-1_riscv64.deb
     digest: 7f1320a2e33a5b9819a683812376d245321624f2fdc605da48eefa299c38c792
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mariadb/mariadb-common_11.8.1-4deepin1_all.deb
     digest: 848333f2b40b586ecf8f0db2b6127398d0423867e689937c4427ab15570e5581
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/m/mysql-defaults/mysql-common_5.8+1.1.0_all.deb
     digest: 729d9b051d2dcda0d0bf51fee21d3b685093314a0b2283926f1eb11f937cb04c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/patch/patch_2.8-2_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/patch/patch_2.8-2_riscv64.deb
     digest: 28b1b35da9af64472c3dc5361d962f3d036d1217042898d0f060114c8672e41d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pkgconf/pkgconf-bin_2.5.1-4_riscv64.deb
     digest: 2fa162b1edf4209e2205220ec902a413a4b73122f90739f9f4f73b546c677bc5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/pkgconf/pkgconf_2.5.1-4_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/pkgconf/pkgconf_2.5.1-4_riscv64.deb
     digest: 4bc6b47e755e58dfe5d2d54f6d775aea604f5832c3bc234ae5f829e7c761ca76
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb
     digest: 4b0fffc886401daa9acfb53e2b190528e3fad37a49b989c4fae6715004fda41e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_riscv64.deb
     digest: 107d2e06b689d0ecc25d7e70cc7de5302f26f7cdb9a10fe7ac66d2bc8958f098
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 1193177fdc10cb628fe9cb3d2129e7dcd6bbd2db24b66c52a1168c5a646f8435
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 3e8432f7de94e872c94d1bd582d1c4f56592256a56872f0368b7483a1b9075ff
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml-qt6_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: a106a50ffd46c3e8d45e70b05bab30bd5af73fda5022cfe604707a7c54a71534
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qmltime_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 7149d23751757d4aa30f80b33a4614a3660fabac333db0af268e89b8ff15b0d1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-animation_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: d97a5a6ba6aaa50dffcfcf2d217995e06cfddbd3fac3bef0c87d154990f6d157
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-folderlistmodel_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: c620fc25729cd7414328a94b20ba3c1fb495143b5b4e343791883833c8372e10
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-platform_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: fc403bf08079cd45651219812f765dfac71c12ee1cc05cbf3d1ef158d1a6a6e2
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-qmlmodels_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 17003a636c7eab347ece379912734229ca1312b4c3bd38809ff99e9e17a52223
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-settings_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: d7bc5326c72767a6fe809dce0bc654679a1ce841b622ba8e38764fd90b5fcbdc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-sharedimage_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: b4b4d5780c50a9d62cad8ad5e3cb158b0a01b4a21a1cea7cea3ff3e6e388fa1d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qt-labs-wavefrontmesh_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 988120ab25642bd0f32a7c02f6ead588a12f6eee71dc969f4e7cad16e0301a95
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_riscv64.deb
     digest: 72c48c137920f33b0d91856319ea8ef9c89e9f595bd3eb2bda6f386451bd5280
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtcore_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 3d8b2529a04cc9db46c34aabcf7ea63c5822c2967f31e927e1f546a8a0d12ab6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/qml6-module-qtmultimedia_6.8.0-0deepin_riscv64.deb
     digest: 06ad674af83e6014f879675f7580099ed3b10e5dea80288a293ef0714ca96452
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-base_6.6.1+dfsg-1deepin7+rb1_riscv64.deb
     digest: f35d98f8878d3d20c4b26ec3a0c91ec40f4b7b8049a0bdcb98923f226128a90f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-models_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: e94679a9a5c9dc83a746d61005ec0e97e51407222def76f2fd7adbad8ca8116e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: c2f90631882754b1229bd126d44aa00e7a24b941e04595d905d9aa7b98a4aedb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml-xmllistmodel_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: ab1e1337313450b3aefac690e361b0b545682d9096be80ba567917dd342f30ff
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: b0709bd27e7b37402f8e0301497898c6506169a18ad2936928c0dde96298d9bd
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.44.1_riscv64.deb
-    digest: a37ddf45bd886c980799d9285b87f6cb83b10fe566708ef0ab293515963bdc68
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/d/dtkdeclarative/qml6-module-qtquick-controls2-styles-chameleon_6.7.44.2_riscv64.deb
+    digest: 866d219613320b35e323dc750af121dabf886906647dfe8f11b4ee60c70f07db
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: daf86ec638dd994d0a7dd0d40b15d33b2f4095e6392dad441c93d30d1c7e443e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-dialogs_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 79a74f3d31206819e68c4e2888f4d5440181af82ca6fb15df1caa6993a7ce854
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 94a9c138392e7a5a567f9e55c283dc3117840294375788dbd6dc769c2c0afa77
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-layouts_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 824be010f06ffa2b3edc67be230f491ac100c08e7b9194bf88fd2110b93cdd8f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-localstorage_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 486c56ec9a30bf63951ddbb78ee66379d362b3ea4f941ae9e202d0c4f95ec7b5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-nativestyle_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 158c7edc74e1ed48f96ca0393adb41ec078f0b79a8fe5c396810f9033d128c96
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-particles_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: e439d2ba74548f579f1a3daa8d4f801a4454e7ffcfa869610079af15a81dc0ab
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 2a692f5f485c256d52611cee9dd8aa04f9401d7c885b89fe444a999ed180f3a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 1c814155e80864a62f08348f24cf3c6a5f3cd34c0f58f915cc711bfd1b3c62c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-tooling_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: a12e6978d106d56fdd73af43dfc19f80dbb2cc352d27d4deb15ee3565ebcd93d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 4d3c2046551cfbbd16be2d23a37bd2eb49c2e69bba85b72fb8e8a10edb4f7ec3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/qml6-module-qtquick3d-spatialaudio_6.8.0-0deepin_riscv64.deb
     digest: 42c80c39ac07ca91cc36f68fe487f34751f4f31c5d3d88aa665a5cbf247f5ce9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: ad9f492596d4e4032f88d837cd787af452e82df6e456e1e88d7bfbf44c6124e7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qml6-module-qttest_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 4cfdf85c7cd14705ce05c8db80b035bfff1594d99140b78609a6d8ba6e1d1fcb
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qml6-module-qttexttospeech_6.8.0-0deepin1_riscv64.deb
     digest: e7332a9bc72d9f178d7e787a1997f80e7d35363d54a3e8e83f1ea21326c52371
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin10_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qml6-module-qtwayland-client-texturesharing_6.8.0-0deepin10_riscv64.deb
     digest: b25fb0d081e30ecc7f162a98b7be5e9ffed23e71c070e9798f6ed0f13c6d2558
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin10_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qml6-module-qtwayland-compositor_6.8.0-0deepin10_riscv64.deb
     digest: 62775d8932a4739e56a811796cae41d2281db83d78d348860dc8fc8e89d054c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qmlscene-qt6_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 1bd8f7676ac54c8c7d056de213e111565d3c78f1bf7c23f312fa2abb5e43e4a1
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_riscv64.deb
     digest: 1a250862673fa606d4ce3b230b15f33bbbf5bbfd28205027953b701b8b64bbb3
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 12455642bb328c6a10b8989e17f6000cd87bd6ffa5be8b0c2bbaffab265abd77
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 955c540c0e62dd72890194f4ca3c95c503a288f7a490489d247bd3378f5183de
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 5935a6d0ddb944b192f705d93a77a692f9fee63950664089dd56170a8b9c756f
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: b79898d85e3ebdf5582d3ac6ca4a11bb2d06bf31a82fb76320390274318f765d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 09811a62cad25368ef56c39935f2d555feb61bcb7b9fd1805fb9ce23709dff84
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-declarative-private-dev_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: 8b9ba91ff65b55fadecd710c5e246192c74f66b1e7485fedaa35fab5582b07a5
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_riscv64.deb
     digest: fe0da86d36d57226a933b280aac8981b23edb4e404fd9aa2495562fc8a5787a6
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-gtk-platformtheme_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 0ee717864fca0d492d6c4906cb775a62f494ef619b338cc498504ed98468665e
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin1_riscv64.deb
     digest: f93a56d4ca50fe6b92bbb3281acfbdc7fdf22dbfa96d02bc8809b7e37600ed63
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_riscv64.deb
     digest: bd04d588bd8509af14c4e39e50c838aa0c88f03e0c6f2f63288ad5c858ddd18c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_riscv64.deb
     digest: 4cf454ca70238ab58447c83ab6ae39aaf9f98343ed75c87f98e52c22b6d820a9
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: e2e9bb1f98ff38d734b78d3eda0187266a703e9530b731b8fc2bc32a763a3003
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin12_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin12_riscv64.deb
     digest: e95b74620da258def24877e7a70d0118399372e9036f7a3e74edc8f59c803bec
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: 2990f0893b202860a208040c819e2ac8ccbd98f0125f35e43fd3a975ca037a7d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qt6-speech-dev_6.8.0-0deepin1_riscv64.deb
     digest: b1c3249a98e45b1c23c176681fcb465c7f966e5a5ddb7cc15158650c67518b1a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qt6-speech-flite-plugin_6.8.0-0deepin1_riscv64.deb
     digest: ffb944b5b7a23ac642f511e42b80780eeda9c6045979bb8798db9555e4b1709c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-speech/qt6-speech-speechd-plugin_6.8.0-0deepin1_riscv64.deb
     digest: 5b51bf9d674d82466e3604ea415ced720bbe6845ad111b94adfa4b6d8d1091cc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin5_riscv64.deb
     digest: c8d467a5ac1d72f17bc36972d2646ba4cfa4b1145809b2e4fdafce5f4cc99071
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-svg/qt6-svg-private-dev_6.8.0-0deepin5_riscv64.deb
     digest: 85ee44301d4eda2dac59d8601e12504a0c78e259a6c845ab7be5f2937604d132
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_riscv64.deb
     digest: cfcbdb6abc4b9d81dea9fe8a1cb63757e8bf244a4558c39ac3fe4203c1ba9cd8
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_riscv64.deb
     digest: 6978dc2163e40aa4987559f86ef0a19688e53b1f4b64a5bca0370e49243e053a
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-tools/qt6-tools-private-dev_6.8.0-0deepin3_riscv64.deb
     digest: 0c5dfdc1401ac799dad22fd7a9c8ee8e6ca50c78ba2c99fb9565ee8ba0a8d14c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-translations/qt6-translations-l10n_6.8.0-0deepin2_all.deb
     digest: dbfa88dae0e66fa60e6558fa80242bb78be8dec5b37ea449f85826b1b48cf25c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin10_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland-dev-tools_6.8.0-0deepin10_riscv64.deb
     digest: cad07c76201992951ec632f128281a19aadafa25d663a8d1cb4cad4f16bd821b
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin10_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland-dev_6.8.0-0deepin10_riscv64.deb
     digest: 02bf4bcb8834065524f07a43f9343e69465e01217de53103fe6cad8f314becd0
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin10_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland-private-dev_6.8.0-0deepin10_riscv64.deb
     digest: ca5d7f4a77108590fda87dcd7e9d466abc107b08154cf2e0126381dba40f0402
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin10_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-wayland/qt6-wayland_6.8.0-0deepin10_riscv64.deb
     digest: e313e9e60fddce298334d685491def2ed6d1c9eb085bd0034715a51e21605316
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-xcb-private-headers-dev_6.8.0+dfsg-0deepin9_all.deb
     digest: e70bbe5b35aa1009f8d3e8d58634052977864bad1d854230add6758ef238b1bc
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin24_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/q/qt6-base/qt6-xdgdesktopportal-platformtheme_6.8.0+dfsg-0deepin24_riscv64.deb
     digest: e0d2b615a79864a13b8de84e771dc9faacd376122a896038187b2d2b020e939c
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/s/spdx-licenses/spdx-licenses_3.8+dfsg-3_all.deb
     digest: aae8ac2b6d3198d297d430cdb97e556365be2ff46d06525008ce071d97ac69c7
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/uos-license-content/uos-license-content_2.0.7_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/uos-license-content/uos-license-content_2.0.7_riscv64.deb
     digest: e0d9457e048d8652ad3fd693a25557fe94546ff4ba2e04cd1fb0ded4eeeae041
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
     digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_riscv64.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin9_riscv64.deb
     digest: 754b734289ba79ff9fc732a1ef0c5baae57a7eb0073941f9b39a69f6fdc04014
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/crimson_runtime/stable_20260708/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_riscv64.deb
-    digest: c2ad747fc268726e4ef3f723f1269428c221e64209c7ffe8aa7cf86e7a56dfb9
+    url: http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.2-1deepin2_riscv64.deb
+    digest: c13f5d73eacd792f7634d93e675bf5424e1a26c0d1e6cdbfe92c08e90fe4ce8d

--- a/sw64/linglong.yaml
+++ b/sw64/linglong.yaml
@@ -4,7 +4,7 @@ package:
   id: org.deepin.runtime.dtk
   name: deepin runtime
   kind: runtime
-  version: 6.7.0.44
+  version: 
   description: Deepin Tool Kit Widget
 
 base: org.deepin.base/25.2.2

--- a/update.go
+++ b/update.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	deepinRepoURL = "http://10.20.64.92:8080/crimson_runtime/stable_20260708"
+	deepinRepoURL = "http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3"
 	uosRepoURL    = "https://pools.uniontech.com/desktop-professional-V25"
 
 	deepinCodename = "stable"


### PR DESCRIPTION
Update repo URL to http://10.20.64.92:8080/crimson_runtime/stable_20260723_test-20260722-v3/
Version: 6.7.0.45